### PR TITLE
Update com.huawei.android.thememanager

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -2315,7 +2315,7 @@
   {
     "id": "com.huawei.android.thememanager",
     "list": "Oem",
-    "description": "Huawei Themes (https://play.google.com/store/apps/details?id=com.huawei.android.thememanager)\nLets you use Huawei themes\nYou should still be able to set wallapers without it. Can someone check?\n",
+    "description": "Huawei Themes (https://play.google.com/store/apps/details?id=com.huawei.android.thememanager)\nLets you use Huawei themes\nSetting Wallpapers directly will no longer work, but the Wallpaper entry in the Settings app will still let you choose wallpapers.\n",
     "dependencies": null,
     "neededBy": null,
     "labels": null,


### PR DESCRIPTION
I tried removing the package, and I found the following:
1. You can no longer set any wallpapers by pinching on the home screen and tapping "Wallpaper", the button just does nothing.
2. There are changes in the Settings under "Home screen & wallpaper":
    2.1. Tapping "Themes" will do nothing.
    2.2. The symbol/picture next to "Wallpaper" vanishes.
    2.3. "Wallpaper" reverts to working like on stock Android (or whatever is on a Moto G6): There's a list of sources, in my case Huawei's "Gallery", "Live wallpapers" and Google's "Photos", which allow you to choose a picture for your wallpaper. Interestingly, you can still blur and toggle scrollability in what seems to be Huawei UI when choosing "Gallery", "Photos" leads to a different UI.

I adjusted the description. Hope this helps!