### PR TITLE
Download `uad_list.json` from Github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +217,12 @@ dependencies = [
  "time",
  "winapi",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clipboard-win"
@@ -412,6 +424,15 @@ dependencies = [
  "core-graphics 0.19.2",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -643,6 +664,18 @@ checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
  "colored",
  "log",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1418,6 +1451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +1969,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +1996,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1966,6 +2036,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -2096,6 +2176,12 @@ dependencies = [
  "smithay-client-toolkit",
  "wayland-client",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spirv"
@@ -2264,6 +2350,7 @@ dependencies = [
  "serde_json",
  "static_init",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -2304,6 +2391,31 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -2497,6 +2609,25 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ chrono = "^0"
 regex = "^1.5"
 toml = "^0"
 dirs = "^4.0"
+ureq = { version = "*", features = ["json"] }
 
 [profile.release]
 opt-level = "s"

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -4,6 +4,8 @@ use crate::core::uad_lists::{Package, PackageState, Removal, UadList};
 use crate::gui::views::list::Selection;
 use crate::gui::widgets::package_row::PackageRow;
 use crate::gui::ICONS;
+use chrono::offset::Utc;
+use chrono::DateTime;
 use iced::{alignment, Length, Text};
 use std::collections::HashMap;
 use std::fs;
@@ -184,5 +186,28 @@ pub fn request_builder(commands: Vec<&str>, package: &str, users: &[User]) -> Ve
             .iter()
             .map(|c| format!("{} {}", c, package))
             .collect()
+    }
+}
+
+pub fn last_modified_date(file: PathBuf) -> DateTime<Utc> {
+    let metadata = fs::metadata(file).unwrap();
+
+    match metadata.modified() {
+        Ok(time) => time.into(),
+        Err(_) => Utc::now(),
+    }
+}
+
+pub fn format_diff_time_from_now(date: DateTime<Utc>) -> String {
+    let now: DateTime<Utc> = Utc::now();
+    let last_update = now - date;
+    if last_update.num_days() == 0 {
+        if last_update.num_hours() == 0 {
+            last_update.num_minutes().to_string() + " min(s) ago"
+        } else {
+            last_update.num_hours().to_string() + " hour(s) ago"
+        }
+    } else {
+        last_update.num_days().to_string() + " day(s) ago"
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 pub fn fetch_packages(
-    uad_lists: &'static HashMap<String, Package>,
+    uad_lists: &HashMap<String, Package>,
     user_id: &Option<&User>,
 ) -> Vec<PackageRow> {
     let all_system_packages = list_all_system_packages(user_id); // installed and uninstalled packages

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -74,7 +74,10 @@ impl Application for UadGui {
     fn new(_flags: ()) -> (Self, Command<Message>) {
         (
             Self::default(),
-            Command::perform(get_device_list(), Message::Init),
+            Command::batch([
+                Command::perform(Self::send_init_message(), Message::AppsAction),
+                Command::perform(get_device_list(), Message::Init),
+            ]),
         )
     }
 
@@ -122,14 +125,10 @@ impl Application for UadGui {
                     };
                     self.apps_view = AppsView::default();
                     self.view = View::List;
-                    Command::perform(
-                        Self::load_phone_packages(self.selected_device.clone().unwrap()),
-                        Message::AppsAction,
-                    )
                 } else {
                     self.selected_device = None;
-                    Command::none()
                 }
+                Command::none()
             }
             Message::AppsPress => {
                 self.view = View::List;
@@ -281,7 +280,7 @@ impl UadGui {
             "ANDROID_SDK: {} | PHONE: {}",
             phone.android_sdk, phone.model
         );
-        AppsMessage::LoadPackages
+        AppsMessage::LoadPackages(None)
     }
 
     pub async fn refresh(i: usize) -> usize {
@@ -292,6 +291,9 @@ impl UadGui {
     }
     pub async fn please_wait() -> AppsMessage {
         AppsMessage::Nothing
+    }
+    pub async fn send_init_message() -> AppsMessage {
+        AppsMessage::InitUadList
     }
 }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -156,8 +156,14 @@ impl Application for UadGui {
                 Command::none()
             }
             Message::AboutAction(msg) => {
-                self.about_view.update(msg);
-                Command::none()
+                self.about_view.update(msg.clone());
+
+                match msg {
+                    AboutMessage::UpdateUadLists => {
+                        Command::perform(Self::send_init_message(), Message::AppsAction)
+                    }
+                    _ => Command::none(),
+                }
             }
             Message::DeviceSelected(device) => {
                 self.selected_device = Some(device);
@@ -293,7 +299,7 @@ impl UadGui {
         AppsMessage::Nothing
     }
     pub async fn send_init_message() -> AppsMessage {
-        AppsMessage::InitUadList
+        AppsMessage::InitUadList(true)
     }
 }
 

--- a/src/gui/views/about.rs
+++ b/src/gui/views/about.rs
@@ -1,4 +1,4 @@
-use crate::core::utils::open_url;
+use crate::core::utils::{format_diff_time_from_now, last_modified_date, open_url};
 use crate::gui::style;
 use crate::gui::views::settings::Settings;
 use crate::CACHE_DIR;
@@ -11,11 +11,13 @@ pub struct About {
     issue_btn: button::State,
     wiki_btn: button::State,
     log_btn: button::State,
+    lists_btn: button::State,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     UrlPressed(PathBuf),
+    UpdateUadLists,
 }
 
 impl About {
@@ -23,6 +25,9 @@ impl About {
         match msg {
             Message::UrlPressed(url) => {
                 open_url(url);
+            }
+            Message::UpdateUadLists => {
+                // Action is taken by UadGui update()
             }
         }
     }
@@ -32,9 +37,31 @@ impl About {
             the removal of pre-installed apps on any Android device.",
         );
 
-        let container = Container::new(about_text)
+        let descr_container = Container::new(about_text)
             .width(Length::Fill)
             .padding(25)
+            .style(style::NavigationContainer(settings.theme.palette));
+
+        let date = last_modified_date(CACHE_DIR.join("uad_lists.json"));
+        let uad_list_text = Text::new(format!("Documentation: v{}", date.format("%Y%m%d")));
+        let last_update_text = Text::new(format!("(last was {})", format_diff_time_from_now(date)))
+            .color(settings.theme.palette.normal.surface);
+        let uad_lists_btn = Button::new(&mut self.lists_btn, Text::new("Update"))
+            .on_press(Message::UpdateUadLists)
+            .padding(5)
+            .style(style::PrimaryButton(settings.theme.palette));
+
+        let uad_list_row = Row::new()
+            .align_items(Alignment::Center)
+            .spacing(10)
+            .push(uad_list_text)
+            .push(uad_lists_btn)
+            .push(last_update_text);
+
+        let update_container = Container::new(uad_list_row)
+            .width(Length::Fill)
+            .center_x()
+            .padding(10)
             .style(style::NavigationContainer(settings.theme.palette));
 
         let website_btn = Button::new(&mut self.website_btn, Text::new("Github page"))
@@ -75,7 +102,8 @@ impl About {
             .spacing(20)
             .align_items(Alignment::Center)
             .push(Space::new(Length::Fill, Length::Shrink))
-            .push(container)
+            .push(descr_container)
+            .push(update_container)
             .push(row);
 
         Container::new(content)


### PR DESCRIPTION
Fix #103 

At the moment, the `uad_lists.json` file containing all the documentation of all the apps is embedded in the binary. This means it get ever updated only when a new version of UAD comes out. This will change! A new UAD build should not be necessary for any package-related changes.

## Current progress:
- [X] Try to download the list from Github when you start UAD
- [X] Cache the file
- [X] Use the cache file if no Internet or fallback to the embedded list
- [X] Display a different waiting message during the download
- [x] Display the version of the list in the UI
- [x] Add a `force update` button in the UI