### PR TITLE
Button to unselect all the packages (closes #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Apps`, `Added`, `Changed`, `Fixed`, `Packaging`
 and `Removed`.
 
+## [Unreleased]
+
+### Added
+- Unselect all button. Note that the selec/unselect all buttons only affect the filtered packages.
+
+### Changed
+- Minor UI changes
+
 ## [0.4.1] - 2022-01-31
 
 ### Fixed

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -54,34 +54,26 @@ pub fn fetch_packages(
     user_package
 }
 
-pub fn update_selection_count(selection: &mut Selection, p_state: PackageState, add: bool) {
-    // Selection can't be negative
-    if !add && selection.selected_packages.is_empty() {
-        selection.enabled = 0;
-        selection.disabled = 0;
-        selection.uninstalled = 0;
-        return;
-    }
-
+pub fn update_selection_count(selection: &mut Selection, p_state: PackageState, add: bool) {    
     match p_state {
         PackageState::Enabled => {
             if add {
                 selection.enabled += 1
-            } else {
+            } else if selection.enabled > 0 {
                 selection.enabled -= 1
             };
         }
         PackageState::Disabled => {
             if add {
                 selection.disabled += 1
-            } else {
+            } else if selection.disabled > 0 {
                 selection.disabled -= 1
             };
         }
         PackageState::Uninstalled => {
             if add {
                 selection.uninstalled += 1
-            } else {
+            } else if selection.uninstalled > 0 {
                 selection.uninstalled -= 1
             };
         }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -54,7 +54,7 @@ pub fn fetch_packages(
     user_package
 }
 
-pub fn update_selection_count(selection: &mut Selection, p_state: PackageState, add: bool) {    
+pub fn update_selection_count(selection: &mut Selection, p_state: PackageState, add: bool) {
     match p_state {
         PackageState::Enabled => {
             if add {

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -139,7 +139,6 @@ impl List {
                                 .selected_packages
                                 .drain_filter(|s_i| *s_i == i);
                         }
-                        
                     } else if !self.selection.selected_packages.contains(&i) {
                         self.selection.selected_packages.push(i);
                         update_selection_count(
@@ -381,7 +380,7 @@ impl List {
                 .width(Length::Fill)
                 .align_items(Alignment::Center)
                 .spacing(10)
-                .padding([0,16,0,7])
+                .padding([0, 16, 0, 7])
                 .push(select_all_checkbox)
                 .push(search_packages)
                 .push(user_picklist)

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 use crate::gui::views::settings::{Phone as SettingsPhone, Settings};
 use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
 use iced::{
-    button, pick_list, scrollable, text_input, Alignment, Button, Checkbox, Column, Command,
-    Container, Element, Length, PickList, Row, Scrollable, Space, Text, TextInput,
+    button, pick_list, scrollable, text_input, Alignment, Button, Column, Command, Container,
+    Element, Length, PickList, Row, Scrollable, Space, Text, TextInput,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -36,7 +36,6 @@ pub struct List {
     phone_packages: Vec<Vec<PackageRow>>, // packages of all users of the phone
     filtered_packages: Vec<usize>, // phone_packages indexes of the selected user (= what you see on screen)
     pub selection: Selection,
-    select_all_checkbox: bool,
     select_all_btn_state: button::State,
     unselect_all_btn_state: button::State,
     search_input: text_input::State,
@@ -123,8 +122,6 @@ impl List {
                 Command::none()
             }
             Message::ToggleAllSelected(selected) => {
-                self.select_all_checkbox = selected;
-
                 for i in self.filtered_packages.clone() {
                     self.phone_packages[*i_user][i].selected = selected;
 
@@ -336,11 +333,6 @@ impl List {
 
             // let package_amount = Text::new(format!("{} packages found", packages.len()));
 
-            let select_all_checkbox =
-                Checkbox::new(self.select_all_checkbox, "", Message::ToggleAllSelected)
-                    .spacing(0)
-                    .style(style::SettingsCheckBox::Enabled(settings.theme.palette));
-
             let user_picklist = PickList::new(
                 &mut self.user_picklist,
                 phone.user_list.clone(),
@@ -380,8 +372,7 @@ impl List {
                 .width(Length::Fill)
                 .align_items(Alignment::Center)
                 .spacing(10)
-                .padding([0, 16, 0, 7])
-                .push(select_all_checkbox)
+                .padding([0, 16, 0, 0])
                 .push(search_packages)
                 .push(user_picklist)
                 .push(divider)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -93,7 +93,7 @@ impl PackageRow {
 
             action_btn = Button::new(
                 &mut self.action_btn_state,
-                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center),
+                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center).width(Length::Units(100)),
             )
             .on_press(Message::ActionPressed);
         } else {
@@ -102,7 +102,7 @@ impl PackageRow {
 
             action_btn = Button::new(
                 &mut self.action_btn_state,
-                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center),
+                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center).width(Length::Units(100)),
             );
         }
 
@@ -114,7 +114,7 @@ impl PackageRow {
                         .align_items(Alignment::Center)
                         .push(selection_checkbox)
                         .push(Text::new(&self.name).width(Length::FillPortion(8)))
-                        .push(action_btn.width(Length::FillPortion(1)).style(button_style)),
+                        .push(action_btn.style(button_style))
                 )
                 .padding(8)
                 .style(style::PackageRow(settings.theme.palette))

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -93,7 +93,9 @@ impl PackageRow {
 
             action_btn = Button::new(
                 &mut self.action_btn_state,
-                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center).width(Length::Units(100)),
+                Text::new(action_text)
+                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .width(Length::Units(100)),
             )
             .on_press(Message::ActionPressed);
         } else {
@@ -102,7 +104,9 @@ impl PackageRow {
 
             action_btn = Button::new(
                 &mut self.action_btn_state,
-                Text::new(action_text).horizontal_alignment(alignment::Horizontal::Center).width(Length::Units(100)),
+                Text::new(action_text)
+                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .width(Length::Units(100)),
             );
         }
 
@@ -114,7 +118,7 @@ impl PackageRow {
                         .align_items(Alignment::Center)
                         .push(selection_checkbox)
                         .push(Text::new(&self.name).width(Length::FillPortion(8)))
-                        .push(action_btn.style(button_style))
+                        .push(action_btn.style(button_style)),
                 )
                 .padding(8)
                 .style(style::PackageRow(settings.theme.palette))


### PR DESCRIPTION
- Add an `unselect all` button
- Add a `select/unselect all` checkbox

Note that this only select/unselect the current filtered packages. For example if you have the `Recommended` filter, it will only affect the packages in this list.

I'm still not sure if I really want the checkbox. The behavior is inevitably confusing. 

For instance:
1) You select all the `Recommended` packages, 
2) You unselect some packages

Should the select/unselect all checkbox be checked? Neither one nor the other. It's just confusing...