### PR TITLE
Big list update

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17642,7 +17642,7 @@
   {
     "id": "com.google.android.inputmethod.latin",
     "list": "Google",
-    "description": "Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\nSometimes the only keyboard app on a phone; Make sure you have another installed before you disable.\n\"Simple Keyboard\" is a good lightweight replacement based on the AOSP Keyboard.\nhttps://f-droid.org/en/packages/rkr.simplekeyboard.inputmethod/",
+    "description": "Gboard – the Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\nSometimes the only keyboard app on a phone; Make sure you have another installed before you disable.\n\"Simple Keyboard\" is a good FOSS, lightweight replacement based on the AOSP Keyboard:\nhttps://f-droid.org/en/packages/rkr.simplekeyboard.inputmethod/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -19180,12 +19180,12 @@
   },
   {
     "id": "com.samsung.android.kgclient",
-    "list": "Pending",
-    "description": "Samsung Pay One Ui 3.0?",
+    "list": "Oem",
+    "description": "Samsung Payment Services\nRemoving this package will LOCK YOU OUT of your device with a full-screen overlay message saying that Device Services was uninstalled in an unauthorised manner. This is persistent upon reboots until a factory data reset is initiated. Filesystem can still be accessed if ADB permissions were granted beforehand.\nUnless you know what you're doing, you shouldn't uninstall this package.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Unsafe"
   },
   {
     "id": "com.lge.updatecenter",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -83,11 +83,11 @@
   {
     "id": "com.sonyericsson.settings.res.overlay_305",
     "list": "Oem",
-    "description": "Some people removed this package. I guess it's only a (useless) overlay the the settings ?\n",
+    "description": "Some overlay for settings? Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonyericsson.startupflagservice",
@@ -110,20 +110,20 @@
   {
     "id": "com.sonyericsson.trackid.res.overlay_305",
     "list": "Oem",
-    "description": "Overlay for Sony trackid\nTrackid was a mobile music and audio search engine (like Shazam). It has been discontinued by Sony.\nREMINDER : An overlay allows apps to display content on top of other apps.\n",
+    "description": "Overlay for TrackID. Overlays are usually themes.\nTrackID was(now discontinued) a music and audio search engine (like Shazam).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonyericsson.trackid.res.overlay",
     "list": "Oem",
-    "description": "Overlay for Sony trackid\nTrackid was a mobile music and audio search engine (like Shazam). It has been discontinued by Sony.\nREMINDER : An overlay allows apps to display content on top of other apps.\n",
+    "description": "Some overlay for TrackID. Overlays are usually themes.\nTrackID was(now discontinued) a music and audio search engine (like Shazam).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonyericsson.unsupportedheadsetnotifier",
@@ -200,11 +200,11 @@
   {
     "id": "com.sonymobile.android.contacts.res.overlay_305",
     "list": "Oem",
-    "description": "Overlay for Sony contacts.\nREMINDER : An overlay allows apps to display content on top of other apps.\n",
+    "description": "Overlay for Sony contacts. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.android.externalkeyboardjp",
@@ -236,11 +236,11 @@
   {
     "id": "com.sonymobile.apnupdater.res.overlay_305",
     "list": "Oem",
-    "description": "Overlay for APN Updater. Useful ?\n",
+    "description": "Overlay for APN Updater. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.aptx.notifier",
@@ -587,11 +587,11 @@
   {
     "id": "com.sonymobile.themes.xperialoops2",
     "list": "Oem",
-    "description": "Sony themes\n",
+    "description": "Sony themes",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.xperialounge.services",
@@ -605,11 +605,11 @@
   {
     "id": "com.sonymobile.xperiaxlivewallpaper.product.res.overlay",
     "list": "Oem",
-    "description": "Some overlay for a live wallaper from Sony?",
+    "description": "Some overlay for a live wallaper from Sony? Overlays are usually themes, but not sure about this one as theming seems weird for live wallpapers. Could be that Sony automatically generates theme packages for all or most system apps, which might generate some unnecessary packages.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.sonymobile.xperiaservices",
@@ -2315,11 +2315,11 @@
   {
     "id": "com.huawei.android.thememanager",
     "list": "Oem",
-    "description": "Huawei Themes (https://play.google.com/store/apps/details?id=com.huawei.android.thememanager)\nLets you use Huawei themes\nSetting Wallpapers directly will no longer work, but the Wallpaper entry in the Settings app will still let you choose wallpapers.\n",
+    "description": "Themes (https://play.google.com/store/apps/details?id=com.huawei.android.thememanager)\nLets you download and use Huawei themes.\nSetting Wallpapers directly will no longer work, but the Wallpaper entry in the Settings app will still let you choose wallpapers.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.huawei.aod",
@@ -4259,20 +4259,20 @@
   {
     "id": "com.samsung.android.themecenter",
     "list": "Oem",
-    "description": "Samsung theme center\nRun at startup and enable you to download theme from samsung\nSafe to remove\n",
+    "description": "Samsung theme center\nRuns at startup and enable you to download theme from samsung\nSafe to remove.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.themestore",
     "list": "Oem",
-    "description": "Galaxy Themes\nOfficial Samsung app for modifying your smartphone's theme.\nhttps://www.samsung.com/global/galaxy/apps/galaxy-themes/\nYou'll still be able to change your wallpaper without this app (from the Gallery app)\n",
+    "description": "Galaxy Themes\nOfficial Samsung app for modifying your smartphone's theme.\nhttps://www.samsung.com/global/galaxy/apps/galaxy-themes/\nYou'll still be able to change your wallpaper without this app (from the Gallery app)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.tripwidget",
@@ -5681,7 +5681,7 @@
   {
     "id": "com.samsung.advp.imssettings",
     "list": "Oem",
-    "description": "Needed for VoLTE (Voice over LTE) https://en.wikipedia.org/wiki/Voice_over_LTE\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nNOTE: this package could be needed for messaging apps that send SMS/RCS code to verify your phone number",
+    "description": "Needed for VoLTE (Voice over LTE) https://en.wikipedia.org/wiki/Voice_over_LTE\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nNOTE: This package could be needed for messaging apps that send SMS/RCS code to verify your phone number.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6464,11 +6464,11 @@
   {
     "id": "com.android.dreams.phototable.overlay",
     "list": "Aosp",
-    "description": "Overlay for com.android.dreams.phototable\n",
+    "description": "Overlay for the phototable daydream? Overlays are usually themes, but not sure about this one.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.egg",
@@ -6540,7 +6540,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.partnerbookmarks",
@@ -6617,7 +6617,7 @@
   {
     "id": "com.android.wallpaper.livepicker.overlay",
     "list": "Aosp",
-    "description": "Overlay for live wallpaper picker?",
+    "description": "Overlay for live wallpaper picker? Overlays are usually themes, but not sure about this one.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7166,20 +7166,20 @@
   {
     "id": "com.android.systemui.theme.dark",
     "list": "Aosp",
-    "description": "Enables you to use Android dark theme.\n",
+    "description": "Enables you to use Android dark theme.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.theme.icon_pack.rounded.systemui",
     "list": "Aosp",
-    "description": "Android icons pack [Rounded].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Rounded].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.timezone.updater",
@@ -7985,7 +7985,7 @@
   {
     "id": "com.zte.weather",
     "list": "Oem",
-    "description": "ZTE Weather app\n)\n",
+    "description": "ZTE Weather app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8282,7 +8282,7 @@
   {
     "id": "com.android.bluetooth.overlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8489,7 +8489,7 @@
   {
     "id": "com.android.theme.icon.circle",
     "list": "Aosp",
-    "description": "Android icons pack [Circle].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Circle].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8498,7 +8498,7 @@
   {
     "id": "com.android.theme.icon.square",
     "list": "Aosp",
-    "description": "Android icons pack [Square].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Square].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8669,7 +8669,7 @@
   {
     "id": "com.oneplus.backuprestore.remoteservice",
     "list": "Oem",
-    "description": "Likely a backend service for OnePlus Switch(com.oneplus.backuprestore).\nProbably safe to disable.",
+    "description": "Likely a backend service for OnePlus Switch(com.oneplus.backuprestore).\nI've never seen it run in the background.\nProbably safe to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8691,7 +8691,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.calendar.black.overlay",
@@ -8700,7 +8700,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.calendar.white.overlay",
@@ -8709,7 +8709,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.camera",
@@ -8749,8 +8749,8 @@
   },
   {
     "id": "com.oneplus.cloud.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for some Oneplus Cloud thing?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8758,8 +8758,8 @@
   },
   {
     "id": "com.oneplus.cloud.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for some Oneplus Cloud thing?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8790,7 +8790,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.contacts.basiccolorwhite.overlay",
@@ -8799,7 +8799,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.coreservice",
@@ -8835,7 +8835,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.deskclock.white.overlay",
@@ -8844,7 +8844,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.diagnosemanager",
@@ -8898,7 +8898,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.filemanager.white.overlay",
@@ -8907,7 +8907,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.gallery",
@@ -8925,7 +8925,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.gamespace.white.overlay",
@@ -8934,7 +8934,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.ifaaservice",
@@ -8970,7 +8970,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.mms.basiccolorwhite.overlay",
@@ -8979,7 +8979,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.note.black.overlay",
@@ -8988,7 +8988,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.note.white.overlay",
@@ -8997,7 +8997,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.odmoverlay.android",
@@ -9063,9 +9063,18 @@
     "removal": "Expert"
   },
   {
+    "id": "com.oneplus.opwlb",
+    "list": "Oem",
+    "description": "Work-Life Balance\nNot present in most Oneplus phones? This functionality might have been superseded by other similar apps, like for example Zen Mode.\nHaven't tested, but probably safe to disable.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
     "id": "com.oneplus.opwlb.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Work-Life Balance?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9073,8 +9082,8 @@
   },
   {
     "id": "com.oneplus.opwlb.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Work-Life Balance?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9092,11 +9101,11 @@
   {
     "id": "com.oneplus.screenrecord",
     "list": "Oem",
-    "description": "Screen Recorder\nThe Android 11 screen recorder with some Oneplus modifications.\nRuns the \"SystemUITileService\" when you have it as one of the quicksettings tiles, but doesn't seem to run in the background outside of that.\nDoesn't have an app icon, but you can create a shortcut to it with the Activity Launcher app.\nhttps://f-droid.org/en/packages/de.szalkowski.activitylauncher/",
+    "description": "Screen Recorder\nThe Android 11 screen recorder with some Oneplus modifications.\nRuns the \"SystemUITileService\" when you have it as one of the quicksettings tiles, but doesn't seem to run in the background outside of that.\nDoesn't have an app icon, but you can create a shortcut to it with the Activity Launcher app (to avoid the background service).\nhttps://f-droid.org/en/packages/de.szalkowski.activitylauncher/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.screenrecord.black.overlay",
@@ -9150,7 +9159,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.security.white.overlay",
@@ -9159,7 +9168,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.ses",
@@ -9195,7 +9204,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.simcontacts.basiccolorwhite.overlay",
@@ -9204,7 +9213,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.sms.smscplugger",
@@ -9218,20 +9227,20 @@
   {
     "id": "com.oneplus.soundrecorder.black.overlay",
     "list": "Oem",
-    "description": "Overlay for Soundrecorder app?",
+    "description": "Theme overlay for Soundrecorder app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.soundrecorder.white.overlay",
     "list": "Oem",
-    "description": "Overlay for Soundrecorder app?",
+    "description": "Theme overlay for Soundrecorder app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.telephonyoptimization",
@@ -9276,7 +9285,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.wifiapsettings.basiccolorwhite.overlay",
@@ -9285,7 +9294,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.qualcomm.qti.devicestatisticsservice",
@@ -9447,7 +9456,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "net.oneplus.weather.basiccolorwhite.overlay",
@@ -9456,12 +9465,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.systemui.gesture.line.overlay",
     "list": "Pending",
-    "description": "\nThese packages seems to be disguished Xiaomi apps and not part of AOSP. Can someone confirm/refute this?\n",
+    "description": "System gesture bar overlay? Probably a bad idea to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9470,7 +9479,7 @@
   {
     "id": "com.android.systemui.navigation.bar.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "System navbar overlay? Probably a bad idea to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9478,8 +9487,8 @@
   },
   {
     "id": "com.android.wifi.resources",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "System Wi-Fi resources",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9487,7 +9496,7 @@
   },
   {
     "id": "com.android.wifi.resources.overlay.common",
-    "list": "Pending",
+    "list": "Oem",
     "description": "System Wi-Fi resources Theme pack\nGuessing it's a pack of themes for some Wi-Fi related system UI, based on the name.",
     "dependencies": null,
     "neededBy": null,
@@ -9496,7 +9505,7 @@
   },
   {
     "id": "com.android.wifi.resources.overlay.target",
-    "list": "Pending",
+    "list": "Oem",
     "description": "System Wi-Fi resources Theme pack\nGuessing it's a pack of themes for some Wi-Fi related system UI, based on the name.",
     "dependencies": null,
     "neededBy": null,
@@ -9533,7 +9542,7 @@
   {
     "id": "com.android.theme.icon.pebble",
     "list": "Aosp",
-    "description": "Android icons pack [Pebble].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Pebble].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9542,7 +9551,7 @@
   {
     "id": "com.android.theme.icon.taperedrect",
     "list": "Aosp",
-    "description": "Android icons pack [Taperedrect].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Taperedrect].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9551,7 +9560,7 @@
   {
     "id": "com.android.theme.icon.vessel",
     "list": "Aosp",
-    "description": "Android icons pack [Vessel].\nYou can safely remove them if you don't use them. But there is no real point in doing so.\n",
+    "description": "Android icons pack [Vessel].\nSafe to remove if you don't use them, but there's no point in doing so as they are simple data containers with no permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9560,7 +9569,7 @@
   {
     "id": "com.android.theme.icon_pack.rounded.themepicker",
     "list": "Aosp",
-    "description": "Obviously related to the \"rounded\" icon pack but the full package is strange. A themepicker class only for a specific icon package?\n\nYou can safely remove them if you don't use any icon packs. But there is no real point in doing so.\n",
+    "description": "Obviously related to the \"rounded\" icon pack but the full package is strange. A themepicker class only for a specific icon package?\nSafe to remove if you don't use them, but there's no point in doing so.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9731,7 +9740,7 @@
   {
     "id": "com.qualcomm.qti.cne",
     "list": "Misc",
-    "description": "CneApp (Connectivity Engine)\nEnables seamless hand-off between mobile data and Wi-Fi networks. Can also dynamically measure network performance to prioritize using the best one (I think that's part of \"Intelligently select the best Wi-Fi\" in settings).\nProbably worth keeping on; I noticed connection reliability getting worse when I disabled it.\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking\nhttps://programmersought.com/article/35091829299/",
+    "description": "CneApp (Connectivity Engine)\nRuns in the background as part of the System.\nEnables seamless hand-off between mobile data and Wi-Fi networks. Can also dynamically measure network performance to prioritize using the best one (I think that's part of \"Intelligently select the best Wi-Fi\" in settings).\nProbably worth keeping on; I noticed connection reliability getting worse when I disabled it.\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking\nhttps://programmersought.com/article/35091829299/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11679,7 +11688,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.lge.leccp",
@@ -11886,7 +11895,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.lge.smartdoctor.webview",
@@ -12125,25 +12134,25 @@
   {
     "id": "com.lge.theme.titan",
     "list": "Oem",
-    "description": "LG Titan theme (labelled 'Platinum' in the theming app).\nSafe to remove if you really want to.\nI could not find the package for the default (LG) theme.\nMake sure you don't delete the package for the theme you're currently using. I don't know what will happen then.\n",
+    "description": "LG Titan theme (labelled 'Platinum' in the theming app).\nSafe to remove, but also probably pointless to do so as most theme packages are just data containers.\nMake sure you don't delete the package for the theme you're currently using. I don't know what will happen then.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.partnerbrowsercustomizations.btl.s600ww.overlay",
     "list": "Oem",
-    "description": "Add Nokia pinned bookmarks in your chromium based browser\n",
+    "description": "Theme overlay for some browser customization?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.calendar.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12152,7 +12161,7 @@
   {
     "id": "com.android.providers.settings.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12161,7 +12170,7 @@
   {
     "id": "com.android.providers.settings.btl.s600ww.overlay",
     "list": "Oem",
-    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12174,7 +12183,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.data.overlay.base.s600ww",
@@ -12210,7 +12219,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.d.base.s600e0",
@@ -12219,7 +12228,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.bboxsbox.app",
@@ -12237,7 +12246,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600ww",
@@ -12255,7 +12264,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600ww",
@@ -12273,7 +12282,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.defaultappconfigure.overlay.base.s600ww",
@@ -12282,7 +12291,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DeviceMonitorControl.data.overlay.base.s600ww",
@@ -12291,7 +12300,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.email.data.overlay.base.s600ww",
@@ -12300,7 +12309,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.factorywizard.overlay.base.s600ww",
@@ -12309,7 +12318,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.foxlauncher.partner",
@@ -12336,7 +12345,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.managedprovisioning.overlay.base.s600ww",
@@ -12345,7 +12354,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.mappartner",
@@ -12363,7 +12372,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.pandorasbox.app",
@@ -12381,12 +12390,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.permissiondetection.overlay.base.s600ww",
     "list": "Oem",
-    "description": "A theme overlay for something?",
+    "description": "A theme overlay for some \"permissiondetection\" package?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12408,7 +12417,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.powersaving.g3.overlay.d.base.s600e0",
@@ -12417,7 +12426,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.providers.downloads.ui.overlay.base.s600ww",
@@ -12426,7 +12435,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.providers.partnerbookmarks.overlay.base.s600ww",
@@ -12435,16 +12444,16 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.providers.weather.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Theme overlay for weather provider? Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "description": "Theme overlay for weather provider?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600ww",
@@ -12462,7 +12471,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.screenlock.overlay.base.s600ww",
@@ -12498,7 +12507,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.stbmonitor.data.overlay.base.s600ww",
@@ -12525,7 +12534,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.weatherservice.overlay.base.s600ww",
@@ -12534,7 +12543,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.fih.infodisplay",
@@ -12566,11 +12575,11 @@
   {
     "id": "com.hmdglobal.datago.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Theme overlay for this telemetry package?",
+    "description": "Theme overlay for a Nokia telemetry package?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.hmdglobal.support",
@@ -12588,7 +12597,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.hmdglobal.camera2",
@@ -12615,7 +12624,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.hdrservice",
@@ -13628,7 +13637,7 @@
   {
     "id": "com.quicinc.voice.activation",
     "list": "Misc",
-    "description": "Qualcomm Voice Assist\nAlways-on voice detection, so obviously always runs in the background.\nProbably worth keeping enabled for battery savings if you use Google Assistant regularly while your screen is off.",
+    "description": "Qualcomm Voice Assist (https://play.google.com/store/apps/details?id=com.quicinc.voice.activation)\nAlways-on voice detection, so obviously always runs in the background.\nProbably worth keeping enabled for battery savings if you use Google Assistant regularly while your screen is off.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13713,7 +13722,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.qmmi",
@@ -14427,9 +14436,18 @@
     "removal": "Recommended"
   },
   {
+    "id": "com.touchtype.swiftkey",
+    "list": "Misc",
+    "description": "Swiftkey Keyboard (https://play.google.com/store/apps/details?id=com.touchtype.swiftkey)\nKeyboard app by TouchType, a Microsoft subsidiary (https://en.wikipedia.org/wiki/SwiftKey)\n4 Trackers + 11 Permissions: https://reports.exodus-privacy.eu.org/en/reports/com.touchtype.swiftkey/latest/\nNOTE: default keyboard on some Nokia and Huawei phones. Make sure you have another keyboard app before disabling this.\nSimple Keyboard is a good FOSS replacement based on the AOSP keyboard: https://f-droid.org/en/packages/rkr.simplekeyboard.inputmethod/",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
     "id": "com.touchtype.swiftkey.res.overlay",
     "list": "Misc",
-    "description": "Swiftkey Keyboard (https://play.google.com/store/apps/details?id=com.touchtype.swiftkey)\nKeyboard app developed by TouchType, a Microsoft subsidiary (https://en.wikipedia.org/wiki/SwiftKey)\nSends \"anonymous\" to Microsoft.\n4 Trackers + 11 Permissions : https://reports.exodus-privacy.eu.org/en/reports/com.touchtype.swiftkey/latest/\nNOTE : default keyboard on some Nokia and Huawei phones. Make sure to have another keyboard before removing this package.\n",
+    "description": "Some overlay for Swiftkey? Overlays are usually themes, but not sure about this one.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15545,11 +15563,11 @@
   {
     "id": "com.miui.videoplayer.overlay",
     "list": "Oem",
-    "description": "Mi Video overlay\nREMINDER : A screen overlay in Android, also referred to as “Draw On Top”, allows an app to display content over another app\n",
+    "description": "Mi Video overlay\nOverlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.miui.virtualsim",
@@ -15824,11 +15842,11 @@
   {
     "id": "com.xiaomi.midrop.overlay",
     "list": "Oem",
-    "description": "Mi Drop overlay\nREMINDER : A screen overlay in Android, also referred to as “Draw On Top”, allows an app to display content over another app\n",
+    "description": "Mi Drop overlay\nOverlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.xiaomi.mipicks",
@@ -15981,7 +15999,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.systemui.overlay.ct",
@@ -15990,7 +16008,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "android.telephony.overlay.cmcc",
@@ -15999,7 +16017,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.mms.overlay.cmcc",
@@ -16008,7 +16026,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.settings.overlay.cmcc",
@@ -16017,7 +16035,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.systemui.overlay.cmcc",
@@ -16026,7 +16044,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.networksettings.overlay.ct",
@@ -16035,7 +16053,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.systemui.overlay.ct",
@@ -16044,7 +16062,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.miui.wmsvc",
@@ -16121,20 +16139,20 @@
   {
     "id": "com.android.thememanager",
     "list": "Oem",
-    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package name\nThis package lets you select and apply themes provided by Xiaomi.\nRemoving this package will disable the ability to change wallpapers on the lock screen.\nFor changing wallpapers on the home screen you will need to use another app.\n",
+    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change lock-screen wallpaper.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.thememanager.module",
     "list": "Oem",
-    "description": "It is obviously related to \"com.android.thememanager\" but not needed for changing wallpapers.\n",
+    "description": "Something related to Xiaomi's theme manager?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.fido.xiaomi.uafclient",
@@ -16427,7 +16445,7 @@
   {
     "id": "com.asus.calculator",
     "list": "Oem",
-    "description": "Asus calculator app\nHas trackers and way to many permissions for a calculator.\nPithus analysis: 817514371bbdb76ec52da4c8456bbc116deec179603099deabbe6fcce6f6ccdb",
+    "description": "Calculator - unit converter (https://play.google.com/store/apps/details?id=com.asus.calculator)\nHas more permissions than a Calculator app reasonably should have.\nConnects to a few Google and currency exchange-rate servers.\nhttps://beta.pithus.org/report/817514371bbdb76ec52da4c8456bbc116deec179603099deabbe6fcce6f6ccdb",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16436,7 +16454,7 @@
   {
     "id": "com.asus.ia.asusapp",
     "list": "Oem",
-    "description": "My Asus (https://play.google.com/store/apps/details?id=com.asus.ia.asusapp)\nAsus service center (support + store)              \n",
+    "description": "My Asus (https://play.google.com/store/apps/details?id=com.asus.ia.asusapp)\nAsus service center (support + store)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16445,7 +16463,7 @@
   {
     "id": "com.asus.soundrecorder",
     "list": "Oem",
-    "description": "Asus Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder).\n  A sound recorder app should not even have the Internet permission.\nPithus analysis: https://beta.pithus.org/report/f4cf38e1c35a04c3579fa198d2abd3ef1ff7be79633d6d3f2bc69c8a69164e1d",
+    "description": "ASUS Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder)\nConnects to Google Analytics and some Asus servers, which is a bit sketchy for a sound recording app..\nhttps://beta.pithus.org/report/f4cf38e1c35a04c3579fa198d2abd3ef1ff7be79633d6d3f2bc69c8a69164e1d",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16895,7 +16913,7 @@
   {
     "id": "com.google.android.apps.subscriptions.red",
     "list": "Google",
-    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red)\n Lets you automatically back up your phone and manage your Google cloud storage.",
+    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red)\nLets you manage your Google cloud storage.\nOccasionally runs in the background.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17075,7 +17093,7 @@
   {
     "id": "com.google.android.feedback",
     "list": "Google",
-    "description": "This is the package that sends crash-report feedback to the Play Store? The crash pop-up still happens with this disabled.\nDoesn't seem to run on its own.\n Has Internet permission and can access to all system logs. All application can use this app to send bug reports.\nPithus analysis: https://beta.pithus.org/report/7041823ff880c207ed2ddacdc92e5ed803b1eb105e4483696d2152bea44903aa ",
+    "description": "This is the package that sends crash-report feedback to the Play Store? The crash pop-up still happens with this disabled.\nDoesn't seem to run on its own.\nHas permission to access system logs and package usage stats. Only connects to 4 Google domains. App developers likely have to go through the Play Store to access any sent data.\nhttps://beta.pithus.org/report/7041823ff880c207ed2ddacdc92e5ed803b1eb105e4483696d2152bea44903aa",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17309,7 +17327,7 @@
   {
     "id": "com.google.ar.core",
     "list": "Google",
-    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nNote: Disabling it breaks some games that depend on it, like Pokemon GO.\nhttps://beta.pithus.org/report/99ea324529f950fe351d22724f8b894cce19c16607fcc9c2855bc906b1f8e644",
+    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nNote: Disabling it can mess with apps that use it, like Pokemon GO.\nhttps://beta.pithus.org/report/99ea324529f950fe351d22724f8b894cce19c16607fcc9c2855bc906b1f8e644",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17506,7 +17524,7 @@
   },
   {
     "id": "com.google.android.overlay.gmsgsaconfig",
-    "list": "Google",
+    "list": "Oem",
     "description": "Overlay theme for gmsgsaconfig? Probably an RRO? https://source.android.com/devices/architecture/rros",
     "dependencies": null,
     "neededBy": null,
@@ -17525,11 +17543,11 @@
   {
     "id": "com.google.android.gms.policy_sidecar_aps",
     "list": "Google",
-    "description": "Talks to Gmail.com and Google.com.\nNeeds a Google Account and Google Play Services to work correctly.\nIt also collects your IMEI. I don't know much more. It is safe to remove.\nGiven its name it could be related to Android auto?\nPithus analysis: https://beta.pithus.org/report/60835b97f38d9e64d4f554a73dab71c892153486a8e0fd81461c3d85359d9fae",
+    "description": "Not sure what purpose it has, but it gets some network and phone data and connects to some Google domains, but never on its own; it has no permissions and never runs on its own, it likely exists as a helper package for other Google services.\nDoesn't seem to exist in newer versions of Android; it's not in Android 11, but it is in 9.\nNeeds a Google Account and Google Play Services to work.\nGiven its name it could be related to Android auto?\nSeems safe to remove, noticed no breakage (didn't test Android Auto tho).\nhttps://beta.pithus.org/report/60835b97f38d9e64d4f554a73dab71c892153486a8e0fd81461c3d85359d9fae",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.gsf",
@@ -17754,7 +17772,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.overlay.modules.permissioncontroller.forframework",
@@ -17763,7 +17781,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.verizon.obdm",
@@ -17907,7 +17925,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.autoregistration.overlay.base.s600id",
@@ -17916,7 +17934,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.autoregistration.overlay.base.s600ww",
@@ -17925,7 +17943,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.autoregistration.overlay.d.base.s600id",
@@ -17934,12 +17952,12 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect",
     "list": "Oem",
-    "description": "Battery protect is advertised to improve battery performance but in practice it drains your battery and kills apps to aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/\n",
+    "description": "Battery protect is advertised to improve battery performance, but in practice it drains your battery and kills apps aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future:\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17952,7 +17970,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600id",
@@ -17961,7 +17979,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600ww",
@@ -17970,7 +17988,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.bboxsbox",
@@ -18006,7 +18024,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600id",
@@ -18015,7 +18033,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager",
@@ -18033,7 +18051,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600id",
@@ -18042,7 +18060,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600ww",
@@ -18051,7 +18069,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent",
@@ -18069,7 +18087,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600id",
@@ -18078,7 +18096,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DbgCfgTool",
@@ -18096,7 +18114,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base.s600id",
@@ -18105,7 +18123,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DeviceMonitorControl",
@@ -18123,7 +18141,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DeviceMonitorControl.data.overlay.base.s600id",
@@ -18132,7 +18150,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.factorywizard",
@@ -18150,7 +18168,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.legalterm",
@@ -18177,7 +18195,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.managedprovisioning.overlay.base.s600id",
@@ -18186,7 +18204,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.nps",
@@ -18204,7 +18222,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.nps.overlay.base.s600id",
@@ -18213,7 +18231,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.pandorasbox",
@@ -18227,7 +18245,7 @@
   {
     "id": "com.evenwell.partnerbrowsercustomizations",
     "list": "Oem",
-    "description": "Adds something partner-related to your browser? Probably adds bookmarks.",
+    "description": "Adds something (Nokia-)partner-related to your browser? Probably adds bookmarks.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18240,7 +18258,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.partnerbrowsercustomizations.overlay.base.s600id",
@@ -18249,7 +18267,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.permissiondetection",
@@ -18285,7 +18303,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.PowerMonitor.overlay.base.s600id",
@@ -18294,7 +18312,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.providers.downloads.overlay.base.s600ww",
@@ -18330,7 +18348,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600id",
@@ -18357,7 +18375,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.retaildemoapp.overlay.base.s600id",
@@ -18366,12 +18384,12 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.settings.data.overlay.base",
     "list": "Oem",
-    "description": "Overlay related to settings [MORE INFO NEEDED]",
+    "description": "Overlay related to settings. Overlays are usually themes.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18402,7 +18420,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.setupwizard.btl.s600ww.overlay",
@@ -18411,7 +18429,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.SetupWizard.overlay.d.base.s600ww",
@@ -18420,7 +18438,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.stbmonitor",
@@ -18438,7 +18456,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.stbmonitor.data.overlay.base.s600id",
@@ -18447,7 +18465,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.telecom.data.overlay.base",
@@ -18456,7 +18474,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.telecom.data.overlay.base.s600id",
@@ -18465,7 +18483,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.UsageStatsLogReceiver",
@@ -18483,7 +18501,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.weather.overlay.base.s600ww",
@@ -18492,7 +18510,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.weatherservice",
@@ -18515,11 +18533,11 @@
   {
     "id": "com.hmdglobal.datago.overlay.base",
     "list": "Oem",
-    "description": "Theme overlay for this telemetry package?",
+    "description": "Theme overlay for a Nokia telemetry package?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.hiya.star",
@@ -18861,7 +18879,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.themes.sou.cid19.silver",
@@ -18870,7 +18888,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.themes.sou.cid20.blue",
@@ -18879,7 +18897,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.themes.sou.cid21.pink",
@@ -18888,7 +18906,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonymobile.xperiaxlivewallpaper",
@@ -19181,16 +19199,16 @@
   {
     "id": "com.lge.theme.black",
     "list": "Oem",
-    "description": "LG Black theme.\nSafe to remove if you really want to.\nI could not find the package for the default (LG) theme.\nMake sure you don't delete the package for the theme you're currently using. I don't know what will happen then.\n",
+    "description": "LG Black theme.\nSafe to remove, but also probably pointless to do so as most theme packages are just data containers.\nMake sure you don't delete the package for the theme you're currently using, I don't know what will happen then.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.lge.theme.white",
     "list": "Oem",
-    "description": "LG White theme.\nSafe to remove if you really want to.\nI could not find the package for the default (LG) theme.\nMake sure you don't delete the package for the theme you're currently using. I don't know what will happen then.\n",
+    "description": "LG White theme.\nSafe to remove, but also probably pointless to do so as most theme packages are just data containers.\nMake sure you don't delete the package for the theme you're currently using, I don't know what will happen then.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -19199,7 +19217,7 @@
   {
     "id": "com.lge.theme.highcontrast",
     "list": "Oem",
-    "description": "LG High Contrast theme.\nSafe to remove if you really want to.\nI could not find the package for the default (LG) theme.\nMake sure you don't delete the package for the theme you're currently using. I don't know what will happen then.\n",
+    "description": "LG High Contrast theme.\nSafe to remove, but also probably pointless to do so as most theme packages are just data containers.\nMake sure you don't delete the package for the theme you're currently using, I don't know what will happen then.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4394,7 +4394,7 @@
   {
     "id": "com.samsung.android.forest",
     "list": "Oem",
-    "description": "",
+    "description": "Digital Wellbeing (old version of com.samsung.android.wellbeing)\nThat's an app for device and app usage tracking and limiting.\nhttps://galaxystore.samsung.com/prepost/000004807357",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -4403,7 +4403,7 @@
   {
     "id": "com.samsung.android.wellbeing",
     "list": "Oem",
-    "description": "Same as Google's Digital Wellbeing app? That's an app for device and app usage tracking and limiting.\nhttps://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing",
+    "description": "Digital Wellbeing\nThat's an app for device and app usage tracking and limiting.\nhttps://galaxystore.samsung.com/prepost/000004807357",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -1233,6 +1233,15 @@
     "removal": "Recommended"
   },
   {
+    "id": "com.sprint.zone",
+    "list": "Carrier",
+    "description": "My Sprint Launcher?\nApparently helps the user find new apps, in addition to some carrier-specific functionality.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
     "id": "com.aetherpal.attdh.se",
     "list": "Carrier",
     "description": "Device Help for AT&T Samsung device\nDeveloped by Aetherpal, a company which sells smart remote controls tools (https://en.wikipedia.org/wiki/AetherPal)\nI guess this app is used for tech support.\n",
@@ -1465,6 +1474,24 @@
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.sec.omadm",
+    "list": "Carrier",
+    "description": "OMADM\nOpen Mobile Alliance Device Management. A protocol for management of mobile devices.\nhttps://en.wikipedia.org/wiki/OMA_Device_Management",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.sec.omadmspr.syncmlphoneif",
+    "list": "Carrier",
+    "description": "OMADM Phone Interface?\nOMADM = Open Mobile Alliance Device Management. A protocol for management of mobile devices.\nhttps://en.wikipedia.org/wiki/OMA_Device_Management",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.synchronoss.dcs.att.r2g",
@@ -2199,6 +2226,15 @@
     "id": "com.huawei.phoneservice",
     "list": "Oem",
     "description": "HiCare (https://play.google.com/store/apps/details?id=com.huawei.phoneservice)\nProvides you common online services including customer services, issue feedback, user guides, service centers and self-service. \n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.huawei.powergenie",
+    "list": "Oem",
+    "description": "Task killer app in EMUI 9+ (Android 9+).\nTask killer apps tend to do more harm than help as they clear cached RAM for no good reason, removing the battery and time savings involved in caching. In addition to the obvious issues with background functionality like notifications.\nFrom issue#104.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3143,11 +3179,11 @@
   {
     "id": "com.samsung.android.app.appsedge",
     "list": "Oem",
-    "description": "Samsung apps edge (https://www.samsung.com/global/galaxy/what-is/apps-edge/)\nDisplays your five most frequently used apps for you to access at a moment’s notice.\n",
+    "description": "Samsung apps edge (https://www.samsung.com/global/galaxy/what-is/apps-edge/)\nDisplays your five most frequently used apps for you to access at a moment’s notice.\nBreaks Split-Screen/Multi-Window according to issue#124.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.app.assistantmenu",
@@ -4358,7 +4394,7 @@
   {
     "id": "com.samsung.android.forest",
     "list": "Oem",
-    "description": "Digital Wellbeing (https://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing)\nis a feature which shows apps dashboard through which one can see how much time any application opened and\nalso swiping to different screens allows you to see breakdowns by day, by hour and by app.",
+    "description": "",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -4367,7 +4403,7 @@
   {
     "id": "com.samsung.android.wellbeing",
     "list": "Oem",
-    "description": "Digital Wellbeing (https://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing)\nis a feature which shows apps dashboard through which one can see how much time any application opened and\nalso swiping to different screens allows you to see breakdowns by day, by hour and by app.",
+    "description": "Same as Google's Digital Wellbeing app? That's an app for device and app usage tracking and limiting.\nhttps://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6318,9 +6354,27 @@
     "removal": "Unsafe"
   },
   {
+    "id": "com.samsung.android.timezone.data.P",
+    "list": "Oem",
+    "description": "Samsung timezone data?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
     "id": "com.samsung.android.timezone.autoupdate_O",
     "list": "Oem",
     "description": "Samsung Time Zone Updater\nUsed to automatically detect appropriate timezone\nREMOVING THIS WILL BOOTLOOP YOUR DEVICE\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.samsung.android.timezone.data.updater",
+    "list": "Oem",
+    "description": "Samsung Time Zone Updater\nUsed to automatically detect appropriate timezone.\nA similar Samsung package apparently bootloops the device if removed, so be careful.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7409,7 +7463,7 @@
   {
     "id": "com.android.providers.telephony",
     "list": "Aosp",
-    "description": "Provider for telephony data.\nHandles phone-related data such as text messages, APN list, e.t.c.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "description": "Provider for telephony data.\nHandles phone-related data such as text messages, APN list, etc.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9574,6 +9628,24 @@
     "neededBy": null,
     "labels": null,
     "removal": "Advanced"
+  },
+  {
+    "id": "com.google.android.apps.assistant",
+    "list": "Google",
+    "description": "Google Assistant Go (https://play.google.com/store/apps/details?id=com.google.android.apps.assistant)\nGo apps are lite-versions of their normal counterparts, made for low-RAM devices.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.google.android.apps.searchlite",
+    "list": "Google",
+    "description": "Google Go (https://play.google.com/store/apps/details?id=com.google.android.apps.searchlite)\nGo apps are lite-versions of their normal counterparts, made for low-RAM devices.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
   },
   {
     "id": "com.google.android.apps.carrier.carrierwifi",
@@ -12796,6 +12868,15 @@
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.coremobility.app.vnotes",
+    "list": "Oem",
+    "description": "Voicemail App?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.heytap.cloud",
@@ -16076,11 +16157,11 @@
   {
     "id": "com.xiaomi.xmsf",
     "list": "Oem",
-    "description": "Xiaomi Service Framework\nSet of API's that Xiaomi apps can used (to put it simply a lot of Xiaomi apps used the same functions which are centralized here)\nI first thought removing this will absolutely break everything but it seems not.\nI don't know the situation now but in 2016 this app constantly tried to do tcp connections in background\nRemoving this big boy will definitively break Mi Cloud and Mi account (and all features needing these 2 things) but you should\nbe okay if you don't use most of Xiaomi apps (what's probably the case if you use this script)\n\nCan someone try to remove this and give feedback? \nCheck if alarms (from Xiaomi Clock & 3-party apps) still work if the phone is in sleep-mode.\n",
+    "description": "Xiaomi Service Framework\nContains a set of API's for Xiaomi apps. Expect widespread breakage of Xiaomi apps/functionality if disabled.\nDisabling will mess with Alarm clock functionality(according to issue#136) and break Mi Cloud and Mi account (and all features that depend on them).\nI don't know about now, but in 2016 this app constantly tried to establish tcp connections in the background.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.wingtech.standard",
@@ -16994,7 +17075,7 @@
   {
     "id": "com.google.android.apps.wellbeing",
     "list": "Google",
-    "description": "Digital Wellbeing (habits tracking tool) (https://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing)\n",
+    "description": "Digital Wellbeing (https://play.google.com/store/apps/details?id=com.google.android.apps.wellbeing)\nLets you track device and app usage and set usage limits.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18655,6 +18736,15 @@
     "neededBy": "",
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.contacts",
+    "list": "Oem",
+    "description": "Samsung contacts app?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.samsung.android.knox.containeragent",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -5681,7 +5681,7 @@
   {
     "id": "com.samsung.advp.imssettings",
     "list": "Oem",
-    "description": "Needed for VoLTE (Voice over LTE) https://en.wikipedia.org/wiki/Voice_over_LTE\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nNOTE: this package could be needed for messaging apps that send SMS/RCS code to verify your phone number (see issue #17)",
+    "description": "Needed for VoLTE (Voice over LTE) https://en.wikipedia.org/wiki/Voice_over_LTE\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nNOTE: this package could be needed for messaging apps that send SMS/RCS code to verify your phone number",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5690,7 +5690,7 @@
   {
     "id": "com.samsung.accessibility",
     "list": "Oem",
-    "description": "Accessibility settings (useful for apps creating virtual buttons such as a pie-menu)\nWeirdly, removing this package can cause a bootloop if you set a lock code on your phone. (see issue #20)\n",
+    "description": "Accessibility settings (useful for apps creating virtual buttons such as a pie-menu)\nWeirdly, removing this package can cause a bootloop if you set a lock code on your phone.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5699,7 +5699,7 @@
   {
     "id": "com.samsung.android.allshare.service.fileshare",
     "list": "Oem",
-    "description": "Wi-Fi Direct\nAllows two devices to establish a direct Wi-Fi connection without requiring a wireless router.\nhttps://www.samsung.com/au/support/mobile-devices/connecting-devices-via-wifi-direct/\nhttps://en.wikipedia.org/wiki/Wi-Fi_Direct\n",
+    "description": "Wi-Fi Direct\nAllows two devices to establish a direct Wi-Fi connection without requiring a wireless router.\nhttps://www.samsung.com/au/support/mobile-devices/connecting-devices-via-wifi-direct/\nhttps://en.wikipedia.org/wiki/Wi-Fi_Direct",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6437,7 +6437,7 @@
   {
     "id": "com.android.companiondevicemanager",
     "list": "Aosp",
-    "description": "Companion Device Manager\nThis handles connections to other devices, like Bluetooth Headphones, desktop Operating Systems, e.t.c.\nOnly needed for Google smart IoT devices (WearOS/Android Wear)",
+    "description": "Companion Device Manager\nThis handles connections to other devices, like Bluetooth Headphones, desktop Operating Systems, etc.\nOnly needed for Google smart IoT devices (WearOS/Android Wear)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8691,7 +8691,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.calendar.black.overlay",
@@ -8700,7 +8700,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.calendar.white.overlay",
@@ -8709,7 +8709,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.camera",
@@ -8718,7 +8718,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.camera.service",
@@ -8790,7 +8790,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.contacts.basiccolorwhite.overlay",
@@ -8799,7 +8799,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.coreservice",
@@ -8826,7 +8826,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.deskclock.black.overlay",
@@ -8835,7 +8835,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.deskclock.white.overlay",
@@ -8844,7 +8844,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.diagnosemanager",
@@ -8898,7 +8898,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.filemanager.white.overlay",
@@ -8907,7 +8907,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.gallery",
@@ -8916,7 +8916,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.gamespace.black.overlay",
@@ -8925,7 +8925,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.gamespace.white.overlay",
@@ -8934,7 +8934,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.ifaaservice",
@@ -8970,7 +8970,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.mms.basiccolorwhite.overlay",
@@ -8979,7 +8979,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.note.black.overlay",
@@ -8988,7 +8988,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.note.white.overlay",
@@ -8997,7 +8997,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.odmoverlay.android",
@@ -9150,7 +9150,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.security.white.overlay",
@@ -9159,7 +9159,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.ses",
@@ -9195,7 +9195,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.simcontacts.basiccolorwhite.overlay",
@@ -9204,7 +9204,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.sms.smscplugger",
@@ -9276,7 +9276,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.wifiapsettings.basiccolorwhite.overlay",
@@ -9285,7 +9285,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.devicestatisticsservice",
@@ -9447,7 +9447,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "net.oneplus.weather.basiccolorwhite.overlay",
@@ -9456,7 +9456,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.systemui.gesture.line.overlay",
@@ -9694,7 +9694,7 @@
   },
   {
     "id": "com.google.android.overlay.modules.modulemetadata.forframework",
-    "list": "Pending",
+    "list": "Aosp",
     "description": "Android System Theme pack\nGuessing it's a pack of themes for the Android System framework based on the name.",
     "dependencies": null,
     "neededBy": null,
@@ -12174,7 +12174,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.data.overlay.base.s600ww",
@@ -12210,7 +12210,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.d.base.s600e0",
@@ -12219,7 +12219,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.bboxsbox.app",
@@ -12237,7 +12237,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600ww",
@@ -12255,7 +12255,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600ww",
@@ -12336,7 +12336,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.managedprovisioning.overlay.base.s600ww",
@@ -12444,7 +12444,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600ww",
@@ -12525,7 +12525,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.weatherservice.overlay.base.s600ww",
@@ -12534,7 +12534,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.fih.infodisplay",
@@ -12615,7 +12615,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.hdrservice",
@@ -13713,7 +13713,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.qualcomm.qti.qmmi",
@@ -16427,11 +16427,11 @@
   {
     "id": "com.asus.calculator",
     "list": "Oem",
-    "description": "Asus calculator app",
+    "description": "Asus calculator app\nHas trackers and way to many permissions for a calculator.\nPithus analysis: 817514371bbdb76ec52da4c8456bbc116deec179603099deabbe6fcce6f6ccdb",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.asus.ia.asusapp",
@@ -16445,11 +16445,11 @@
   {
     "id": "com.asus.soundrecorder",
     "list": "Oem",
-    "description": "Asus Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder)",
+    "description": "Asus Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder).\n  A sound recorder app should not even have the Internet permission.\nPithus analysis: https://beta.pithus.org/report/f4cf38e1c35a04c3579fa198d2abd3ef1ff7be79633d6d3f2bc69c8a69164e1d",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.android.hotwordenrollment.xgoogle",
@@ -16895,7 +16895,7 @@
   {
     "id": "com.google.android.apps.subscriptions.red",
     "list": "Google",
-    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red)",
+    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red)\n Lets you automatically back up your phone and manage your Google cloud storage.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17079,7 +17079,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.google.android.googlequicksearchbox",
@@ -17313,7 +17313,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.google.ar.lens",
@@ -17529,7 +17529,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.google.android.gsf",
@@ -17952,7 +17952,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600id",
@@ -17961,7 +17961,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600ww",
@@ -17970,7 +17970,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.bboxsbox",
@@ -18006,7 +18006,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600id",
@@ -18015,7 +18015,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.custmanager",
@@ -18033,7 +18033,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600id",
@@ -18042,7 +18042,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600ww",
@@ -18051,7 +18051,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.dataagent",
@@ -18069,7 +18069,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600id",
@@ -18077,7 +18077,7 @@
     "description": "Theme overlay for Data Agent?",
     "dependencies": null,
     "neededBy": "",
-    "labels": null,
+    "labels": nullAdvanced
     "removal": "Expert"
   },
   {
@@ -18087,7 +18087,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base",
@@ -18096,7 +18096,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base.s600id",
@@ -18330,7 +18330,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600id",
@@ -18492,7 +18492,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.evenwell.weatherservice",
@@ -18501,7 +18501,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.hmdglobal.datago",
@@ -19383,7 +19383,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.mi.globalbrowser",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -9694,7 +9694,7 @@
   },
   {
     "id": "com.google.android.overlay.modules.modulemetadata.forframework",
-    "list": "Aosp",
+    "list": "Oem",
     "description": "Android System Theme pack\nGuessing it's a pack of themes for the Android System framework based on the name.",
     "dependencies": null,
     "neededBy": null,
@@ -12237,7 +12237,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600ww",
@@ -18077,8 +18077,8 @@
     "description": "Theme overlay for Data Agent?",
     "dependencies": null,
     "neededBy": "",
-    "labels": nullAdvanced
-    "removal": "Expert"
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.DbgCfgTool",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -6414,7 +6414,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.android.bookmarkprovider",
@@ -6535,7 +6535,7 @@
   },
   {
     "id": "com.android.email.partnerprovider.overlay",
-    "list": "Pending",
+    "list": "Oem",
     "description": "Some overlay for partnerprovider?",
     "dependencies": null,
     "neededBy": null,
@@ -17075,7 +17075,7 @@
   {
     "id": "com.google.android.feedback",
     "list": "Google",
-    "description": "This is the package that sends crash-report feedback to the Play Store? The crash pop-up still happens with this disabled.\nDoesn't seem to run on its own.",
+    "description": "This is the package that sends crash-report feedback to the Play Store? The crash pop-up still happens with this disabled.\nDoesn't seem to run on its own.\n Has Internet permission and can access to all system logs. All application can use this app to send bug reports.\nPithus analysis: https://beta.pithus.org/report/7041823ff880c207ed2ddacdc92e5ed803b1eb105e4483696d2152bea44903aa ",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17309,7 +17309,7 @@
   {
     "id": "com.google.ar.core",
     "list": "Google",
-    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nDisabling breaks some games that depend on it, like Pokemon GO.",
+    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nRuns at boot and sends data to google. Pithus analysis: https://beta.pithus.org/report/99ea324529f950fe351d22724f8b894cce19c16607fcc9c2855bc906b1f8e644\nNote: Disabling it breaks some games that depend on it, like Pokemon GO.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17525,7 +17525,7 @@
   {
     "id": "com.google.android.gms.policy_sidecar_aps",
     "list": "Google",
-    "description": "Talks to Gmail.com and Google.com.\nNeeds a Google Account and Google Play Services to work correctly.\nI don't know much more but it's sufficient to know you can debloat it.\nGiven its name it could be related to Android auto?\nhttps://www.hybrid-analysis.com/sample/c710b66d043026007666966d933e3a1ed29720c5009764c01b5f056232a3518a?environmentId=200",
+    "description": "Talks to Gmail.com and Google.com.\nNeeds a Google Account and Google Play Services to work correctly.\nIt also collects your IMEI. I don't know much more. It is safe to remove.\nGiven its name it could be related to Android auto?\nPithus analysis: https://beta.pithus.org/report/60835b97f38d9e64d4f554a73dab71c892153486a8e0fd81461c3d85359d9fae",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -6536,7 +6536,7 @@
   {
     "id": "com.android.email.partnerprovider.overlay",
     "list": "Oem",
-    "description": "Some overlay for partnerprovider?",
+    "description": "Theme overlay for partnerprovider?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17309,7 +17309,7 @@
   {
     "id": "com.google.ar.core",
     "list": "Google",
-    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nRuns at boot and sends data to google. Pithus analysis: https://beta.pithus.org/report/99ea324529f950fe351d22724f8b894cce19c16607fcc9c2855bc906b1f8e644\nNote: Disabling it breaks some games that depend on it, like Pokemon GO.",
+    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nNote: Disabling it breaks some games that depend on it, like Pokemon GO.\nhttps://beta.pithus.org/report/99ea324529f950fe351d22724f8b894cce19c16607fcc9c2855bc906b1f8e644",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -47,7 +47,7 @@
   {
     "id": "com.sonyericsson.mtp",
     "list": "Oem",
-    "description": "MTP extension service\nI think it's needed transfert data from you phone to a PC when using the Media Transfert Protocol (MTP).\nDoes MTP still work if you delete this package ?\n",
+    "description": "MTP extension service\nNeeded to transfer data from phone to PC through MTP? (Media Transfer Protocol)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -56,20 +56,20 @@
   {
     "id": "com.sonyericsson.mtp.extension.backuprestore",
     "list": "Oem",
-    "description": "Backup/Restore Sony feature.\nIt enable you to backup (Contacts, call logs, text messages, calendar, settings, bookmarks & media files)\nNOTE : I don't think this feature can backup your messages or calendars for instance if you don't use the Sony stock app.\nhttps://support.sonymobile.com/global-en/xperiaz2/userguide/backing-up-and-restoring-content-on-a-device/\n",
+    "description": "Backup/Restore Sony feature.\nEnables you to backup contacts, call logs, text messages, calendar, settings, bookmarks & media files.\nNOTE: I don't think this feature can backup your messages or calendars for instance if you don't use the Sony stock app.\nhttps://support.sonymobile.com/global-en/xperiaz2/userguide/backing-up-and-restoring-content-on-a-device/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.sonyericsson.mtp.extension.update",
     "list": "Oem",
-    "description": "Update service for MTP Extension.\nI don't know what it really does. Update drivers ? \n",
+    "description": "Update service for MTP Extension.\nUpdates something for the MTP extension?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.sonyericsson.music",
@@ -227,7 +227,7 @@
   {
     "id": "com.sonymobile.apnupdater",
     "list": "Oem",
-    "description": "I guess it automatically updates your APN settings if your carrier changes it ?\nI thought it was the role of com.android.carrierconfig.\nNOTE : The probability that your carrier's APN change is very low.\nAPN : https://tamingthedroid.com/what-apn-settings-mean\n",
+    "description": "Automatically updates APN settings if your carrier changes them? I thought that was the role of com.android.carrierconfig\nAPN: https://tamingthedroid.com/what-apn-settings-mean",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -281,7 +281,7 @@
   {
     "id": "com.sonymobile.cellbroadcast.notification",
     "list": "Oem",
-    "description": "Cell information\nCell broadcast is a method of sending messages to multiple mobile telephone users in a defined area at the same time.\nIt is often used for regional emergency alerts.\nI think this package only handles notifications for broadcast cell, not the implementation.\nIt seems to me that broadcast SMS use normal notifications so there is chances that this package provide special notification for Sony SMS app ? \n",
+    "description": "Cell information\nCell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know\nI think this package only handles notifications for broadcasts, not the implementation.\nIt seems like broadcast SMS use normal notifications so there is a chance this package provides special notification for Sony SMS app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -461,11 +461,11 @@
   {
     "id": "com.sonymobile.mtp.extension.fotaupdate",
     "list": "Oem",
-    "description": "fota update service\nFOTA = Firmware Over-The-Air \nFOTA allows manufacturers to remotely install new software updates, features and services.\nGiven there is \"mtp.extension\" in the package name, I think it lets you update your phone via your PC.\nWhat's weird is that it should be called SEUS then (https://www.mobilefun.co.uk/blog/2008/06/software-updates-sony-ericsson/)\n",
+    "description": "fota update service\nFOTA = Firmware Over-The-Air\nFOTA allows manufacturers to remotely install new software updates, features and services.\nGiven there is \"mtp.extension\" in the package name, I think it lets you update your phone via your PC.\nWhat's weird is that it should be called SEUS then (https://www.mobilefun.co.uk/blog/2008/06/software-updates-sony-ericsson/)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.sonymobile.music.googlelyricsplugin",
@@ -605,7 +605,7 @@
   {
     "id": "com.sonymobile.xperiaxlivewallpaper.product.res.overlay",
     "list": "Oem",
-    "description": "Xperia Loops\nUseless and ugly live wallaper from Sony.\n",
+    "description": "Some overlay for a live wallaper from Sony?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -1937,7 +1937,7 @@
   {
     "id": "com.huawei.fido.uafclient",
     "list": "Oem",
-    "description": "UAF client for FIDO.\nFido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\n#\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device \nto the online service and using a local authentication mechanism such as iris or fingerprint recognition. .\nhttps://developers.google.com/identity/fido/android/native-apps\nSafe to remove if you don't use password-less authentification to access online servics.\n",
+    "description": "UAF client for FIDO.\nFido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device to the online service and using a local authentication mechanism such as iris or fingerprint recognition.\nhttps://developers.google.com/identity/fido/android/native-apps\nSafe to remove if you don't use password-less authentification to access online servics.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2072,7 +2072,7 @@
   {
     "id": "com.huawei.hwasm",
     "list": "Oem",
-    "description": "FIDO UAF Autenthicator-Specific Module.\nSee 'com.huawei.fido.uafclient' for FIDO explaination.\nThe UAF Authenticator-Specific Module (ASM) is a software interface on top of UAF authenticators which gives a standardized way for FIDO UAF clients \nto detect and access the functionality of UAF authenticators and hides internal communication complexity from FIDO UAF Client.\nSource : https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-asm-api-v1.0-ps-20141208.html\n",
+    "description": "FIDO UAF Autenthicator-Specific Module.\nSee 'com.huawei.fido.uafclient' for FIDO explaination.\nThe UAF Authenticator-Specific Module (ASM) is a software interface on top of UAF authenticators which gives a standardized way for FIDO UAF clients to detect and access the functionality of UAF authenticators and hides internal communication complexity from FIDO UAF Client.\nhttps://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-asm-api-v1.0-ps-20141208.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2324,7 +2324,7 @@
   {
     "id": "com.huawei.aod",
     "list": "Oem",
-    "description": "Always On Display feature.\nDrain battery (though not much on OLED screens) for nothing really useful.\nRedSkull23 says it's unsafe to remove it. Does it bootloop ? \n",
+    "description": "Always On Display\nWhen enabled in settings it shows clock and notifications when you raise the phone or touch the screen.\nThis is basically a lower-power lock-screen. It could in theory reduce power draw if you check notifications/clock often as OLED screens draw minimal power showing a mostly black screen(black = pixel off), but in practice the number of times you'll unintentionally trigger it will likely eat up any potential power savings and more. And if your device doesn't have an OLED screen this will draw way more power.\nMost of these power savings could be applied to your standard lock-screen simply by making your background image completely black.\nRedSkull23 says it's unsafe to remove. Does it bootloop?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2423,7 +2423,7 @@
   {
     "id": "android.autoinstalls.config.motorola.layout",
     "list": "Oem",
-    "description": "\nDevice configuration for Motorola \nAutoInstall allows manufacturers to force installation of apps.\nJust a layout ? \n",
+    "description": "Device configuration for Motorola\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).\nA layout?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2477,7 +2477,7 @@
   {
     "id": "com.motorola.android.providers.chromehomepage",
     "list": "Oem",
-    "description": "Seems to only prodive the \"home\" symbol in Chrome.\nhttps://forum.xda-developers.com/android/apps-games/app-chrome-homepage-t3695804\n",
+    "description": "Seems to provide the \"Home\"-button functionality in Chrome.\nhttps://forum.xda-developers.com/android/apps-games/app-chrome-homepage-t3695804",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2702,7 +2702,7 @@
   {
     "id": "com.motorola.motodisplay",
     "list": "Oem",
-    "description": "Moto Display (https://play.google.com/store/apps/details?id=com.motorola.motodisplay)\nDisplays notifications with the screen off (it's like the Always On Display feature from Samsung)\nhttps://support.motorola.com/uk/en/solution/ms108519\n",
+    "description": "Moto Display (https://play.google.com/store/apps/details?id=com.motorola.motodisplay)\nDisplays notifications with the screen off (like the Always On Display feature from other OEMs)\nhttps://support.motorola.com/uk/en/solution/ms108519",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2828,7 +2828,7 @@
   {
     "id": "com.motorola.faceunlock",
     "list": "Oem",
-    "description": "Moto Face Unlock (https://play.google.com/store/apps/details?id=com.motorola.faceunlock)\nLets you conveniently unlock your device by simply looking at the display. \nNote : Using face unlock is a really bad idea (security and privacy wise) : \nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/\n",
+    "description": "Moto Face Unlock (https://play.google.com/store/apps/details?id=com.motorola.faceunlock)\nUnlock your device by simply looking at the display.\nFace unlock is bad for security and privacy:\nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2837,7 +2837,7 @@
   {
     "id": "com.motorola.faceunlocktrustagent",
     "list": "Oem",
-    "description": "Motorola Face Unlock Agent\nTrust agent is a service that notifies the system about whether it believes the environment of the device to be trusted.\nThe exact meaning of 'trusted' is up to the trust agent to define. \nThe system lockscreen listens for trust events, it can change its behaviour based on the trust state of the current user\n(e.g detection of a trusted face)\nhttps://nelenkov.blogspot.com/2014/12/dissecting-lollipops-smart-lock.html\n",
+    "description": "Motorola Face Unlock Agent\nTrust agent is a service that notifies the system about whether it believes the environment of the device is trusted.\nThe meaning of 'trusted' is up to the trust agent to define.\nThe system lockscreen listens for trust events, it can change its behaviour based on the trust state of the current user (e.g detection of a trusted face)\nhttps://nelenkov.blogspot.com/2014/12/dissecting-lollipops-smart-lock.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2846,7 +2846,7 @@
   {
     "id": "com.motorola.imagertuning_lake",
     "list": "Oem",
-    "description": "Imager Tuning (https://play.google.com/store/apps/details?id=com.motorola.imagertuning_athene)\nNaming convention: imagertuning_[PHONE CODENAME]\nIt's supposed to improve color, sharpness, noise when taking photo with the stock camera. \nThe results are not that good (see reviews). I let you see the difference with/without the camera tuning.\n",
+    "description": "Imager Tuning (https://play.google.com/store/apps/details?id=com.motorola.imagertuning_athene)\nNaming convention: imagertuning_[PHONE CODENAME]\nThis is the custom camera image processing stack on Motorola devices. It's generally important for improving image quality.\nPlaystore reviews indicate that it slows down the camera app significantly for some users (probably a bug).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2855,11 +2855,11 @@
   {
     "id": "com.motorola.invisiblenet",
     "list": "Oem",
-    "description": "Invisible net\nHard to find info about this one. I only found something from a patent (http://www.freepatentsonline.com/5469497.html).\nIt's a Google patent and Google owned Motorola so maybe it is that's it.\nIt seems to implement the ICMS local area network. ICMS means Interactive Call Management Subsystems.\nI couldn't find more info about ICMS. It's strange that this is so badly documented. \n",
+    "description": "Invisible net\nHard to find info about this one. I only found something from a patent: http://www.freepatentsonline.com/5469497.html\nIt's a Google patent and Google owned Motorola so maybe it is that's it.\nIt seems to implement the ICMS local area network. ICMS means Interactive Call Management Subsystems. Couldn't find more info about ICMS. It's strange that this is so badly documented.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.motorola.launcher3",
@@ -2963,7 +2963,7 @@
   {
     "id": "com.motorola.android.providers.settings",
     "list": "Oem",
-    "description": "Removal causes bootloop. Which is fairly common with settings providers.\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Removal causes bootloop. Which is common with settings providers.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nFor example: the Settings provider. It stores the settings from your Settings app, which apps can query for info on whether you for example have Dark Mode turned on or off.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -2999,7 +2999,7 @@
   {
     "id": "android.autoinstalls.config.samsung",
     "list": "Oem",
-    "description": "\nSamsung's implementation of the \"necessary apps\" that need to be downloaded upon first setting up the device.\n",
+    "description": "AutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3008,7 +3008,7 @@
   {
     "id": "com.aura.oobe.samsung",
     "list": "Oem",
-    "description": "AppCloud\nIt offers the \"Aura out-of-the-box experience\" (OOBE)\nIt's an app who promotes some other apps (and encourages you to install them)\nDevelopped by IronSource (an Israeli  advertising company)\nhttps://en.wikipedia.org/wiki/IronSource\nhttps://aura.ironsrc.com/tools/drive-app-downloads/\nhttps://arxiv.org/pdf/2010.10088.pdf\nHas way too much permissions.\n",
+    "description": "AppCloud\nIt offers the \"Aura Out-Of-the-Box Experience\" (OOBE)\nIt's an app that promotes other apps.\nDevelopped by IronSource, an Israeli advertising company.\nhttps://en.wikipedia.org/wiki/IronSource\nhttps://aura.ironsrc.com/tools/drive-app-downloads/\nhttps://arxiv.org/pdf/2010.10088.pdf\nHas way too many permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3035,7 +3035,7 @@
   {
     "id": "com.knox.vpn.proxyhandler",
     "list": "Oem",
-    "description": "Third-party that provides caller profile information to help consumers identify incoming calls and block unwanted ones.\nhttps://en.wikipedia.org/wiki/Hiya_(company)\nhttps://hiya.com/ \nNOTE : Never trust a company which promotes spam blocking features \nhttps://itmunch.com/robocall-caught-sending-customers-confidential-data-without-consent/\n#\nHave a look at their privacy policy. That's... pretty scary : https://hiya.com/fr/hiya-data-policy\nNeeded for Samsung Smart Call (com.samsung.android.smartcallprovider)\n\nSamsung Knox allows business and personal content to \"securely\" coexist on the same handset. \nThis package handle proxy along side KNOX\n",
+    "description": "Third-party package that provides caller profile information to help consumers identify incoming calls and block unwanted ones.\nhttps://en.wikipedia.org/wiki/Hiya_(company)\nhttps://hiya.com/\nNOTE: Never trust a company that promotes spam blocking features.\nhttps://itmunch.com/robocall-caught-sending-customers-confidential-data-without-consent/\nHave a look at their privacy policy. It's... pretty scary: https://hiya.com/fr/hiya-data-policy\nNeeded for Samsung Smart Call (com.samsung.android.smartcallprovider)\nSamsung Knox allows business and personal content to \"securely\" coexist on the same handset.\nThis package handles proxies alongside KNOX.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3044,7 +3044,7 @@
   {
     "id": "com.mygalaxy",
     "list": "Oem",
-    "description": "My Galaxy (https://play.google.com/store/apps/details?id=com.mygalaxy)\nEntertainment hub and life-services application\nLets your access videos, music and gaming and gives quick access to services such as cabs, movies, recharge and bill payment, \nfood ordering, travel, hyper local deals and Samsung Care, among others.\n",
+    "description": "My Galaxy (https://play.google.com/store/apps/details?id=com.mygalaxy)\nEntertainment hub and life-services application.\nLets you access videos, music and gaming and gives quick access to services such as cabs, movies, recharge, bill payment, food ordering, travel, hyper local deals and Samsung Care, among others.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3539,7 +3539,7 @@
   {
     "id": "com.samsung.android.bbc.fileprovider",
     "list": "Oem",
-    "description": "KNOX BBC Provider.\nProvider for KNOX BBC\nReminder : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps.\n",
+    "description": "KNOX BBC Provider.\nProvider for KNOX BBC\nContent providers encapsulate data, providing centralized management of data shared between apps.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3611,7 +3611,7 @@
   {
     "id": "com.samsung.android.dqagent",
     "list": "Oem",
-    "description": "Samsung Device Quality Agent\nMonitors how the device uses wifi. Has the ability to identify network operator related data.\nFind mention of some packages in the Java code : \n - com.samsung.android.app.mobiledoctor (https://play.google.com/store/apps/details?id=com.samsung.heartwiseVcr)\n - com.samsung.android.dhr (Device Health Report)\n - om.salab.act (https://play.google.com/store/apps/details?id=com.jquiz.act)\n - kr.co.avad.diagnostictool (unkown stuff from South Korea)\n\n 2 hard-coded URL strings : PRD=\"https://dc.dqa.samsung.com\" | STG=\"https://stg-dc.dqa.samsung.com\"\n PRD = Portable recording devices and STG = Security Threat Group 2 terms related to law enforcment.\n",
+    "description": "Samsung Device Quality Agent\nMonitors how the device uses wifi. Has the ability to identify network operator related data.\nFound mention of some packages in the Java code:\n- com.samsung.android.app.mobiledoctor (https://play.google.com/store/apps/details?id=com.samsung.heartwiseVcr)\n- com.samsung.android.dhr (Device Health Report)\n- om.salab.act (https://play.google.com/store/apps/details?id=com.jquiz.act)\n- kr.co.avad.diagnostictool (unkown stuff from South Korea)\n\n2 hard-coded URLs:\nPRD = https://dc.dqa.samsung.com\nSTG = https://stg-dc.dqa.samsung.com\nPRD = Portable Recording Device, STG = Security Threat Group. 2 terms related to law enforcment.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -3944,7 +3944,7 @@
   {
     "id": "com.samsung.android.providers.context",
     "list": "Oem",
-    "description": "Spyware \nhttps://www.eteknix.com/samsungs-context-service-may-take-data-collection-surveillance-worrying-levels/\nhttps://www.theinquirer.net/inquirer/news/2328363/samsung-context-service-will-collect-user-data-to-share-with-developers\n",
+    "description": "Spyware\nhttps://www.eteknix.com/samsungs-context-service-may-take-data-collection-surveillance-worrying-levels/\nhttps://www.theinquirer.net/inquirer/news/2328363/samsung-context-service-will-collect-user-data-to-share-with-developers\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -4601,7 +4601,7 @@
   {
     "id": "com.samsung.rcs",
     "list": "Oem",
-    "description": "RCS (Rich Communication Services)\nHas permissions linked to com.samsung.cmh, and com.samsung.android.visionintelligence (and I don't understand why)\nRCS is a communication protocol between mobile telephone carriers and between phone and carrier, aiming at replacing SMS.\nhttps://en.wikipedia.org/wiki/Rich_Communication_Services\nNote that it uses IP protocol so you need to connect to Wifi/3G/4G...  to take advantage of it.\n#\nIt's a hot mess right now. It aims at being universal but you still need to have a Samsung Messages \nor Google Message. 3-party apps can't support it because google hasn't released a public API yet.\n\nIn a lot of country messages go through Google's Jibe servers.\nhttps://jibe.google.com/policies/terms/\n#\nhttps://pocketnow.com/why-you-should-probably-avoid-googles-rcs-text-messaging-chat-feature\n",
+    "description": "RCS (Rich Communication Services)\nHas permissions linked to com.samsung.cmh, and com.samsung.android.visionintelligence (and I don't understand why).\nRCS is a communication protocol between mobile telephone carriers and between phone and carrier, aiming at replacing SMS.\nhttps://en.wikipedia.org/wiki/Rich_Communication_Services\nUses IP protocol, so it needs an internet connection.\nIt's a hot mess right now. It aims at being universal but only exists in Samsung Messages and Google Messages, because Google hasn't released a public API yet, so 3rd-party apps can't support it.\nIn a lot of countries messages go through Google's Jibe servers.\nhttps://jibe.google.com/policies/terms/\nhttps://pocketnow.com/why-you-should-probably-avoid-googles-rcs-text-messaging-chat-feature",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5123,7 +5123,7 @@
   {
     "id": "com.sec.android.fido.uaf.asm",
     "list": "Oem",
-    "description": "Fido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\n#\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device \nto the online service and using a local authentication mechanism such as iris or fingerprint recognition. .\nhttps://developers.google.com/identity/fido/android/native-apps\n#\nThe UAF Authenticator-Specific Module (ASM) is a software interface on top of UAF authenticators which gives a standardized way for FIDO UAF clients \nto detect and access the functionality of UAF authenticators and hides internal communication complexity from FIDO UAF Client.\nSource : https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-asm-api-v1.0-ps-20141208.html\n#\nSafe to remove if you don't use password-less authentification to access online servics\n",
+    "description": "Fido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device to the online service and using a local authentication mechanism such as iris or fingerprint recognition.\nhttps://developers.google.com/identity/fido/android/native-apps\nThe UAF Authenticator-Specific Module (ASM) is a software interface on top of UAF authenticators which gives a standardized way for FIDO UAF clients to detect and access the functionality of UAF authenticators and hides internal communication complexity from FIDO UAF Client.\nhttps://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-asm-api-v1.0-ps-20141208.html\nSafe to remove if you don't use password-less authentification to access online services.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5177,7 +5177,7 @@
   {
     "id": "com.sec.android.providers.security",
     "list": "Oem",
-    "description": "Provider (handles access) for certain security policies\nIt seems to provide access to a password database but I don't know under what circumstances this database is used.\nThis provider is only usable by Samsung apps \nI see a com.android.security.PASSWORD_EXPIRED intent filter in the AndroidManifest so my guess is it handles password policies.\nTypically, a policy that could force user to change their password after a certain amount of time.\nThis is mainly useful for enterprises.\n",
+    "description": "Provider of password security policies?\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html\nSeems to provide access to a password database but I don't know under what circumstances this database is used.\nThis provider is only usable by Samsung apps.\nI see a com.android.security.PASSWORD_EXPIRED intent filter in the AndroidManifest so my guess is it handles password policies.\nFor example: A policy could force a user to change their password after a certain amount of time. That's a common policy in enterprise work.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5186,7 +5186,7 @@
   {
     "id": "com.sec.android.provider.snote",
     "list": "Oem",
-    "description": "Content provider for S Note (https://www.samsung.com/global/galaxy/apps/samsung-notes/).\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Content provider for S Note (https://www.samsung.com/global/galaxy/apps/samsung-notes/).\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5411,7 +5411,7 @@
   {
     "id": "com.sec.imslogger",
     "list": "Oem",
-    "description": "IMS Logger provide logging optins.\nSecurity flaw : https://nitter.net/fs0c131y/status/1115889065285562368\n",
+    "description": "IMS Logger provides logging opt-ins.\nSecurity flaw: https://nitter.net/fs0c131y/status/1115889065285562368",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5528,7 +5528,7 @@
   {
     "id": "com.sec.mldapchecker",
     "list": "Oem",
-    "description": "MLDAP log. Still a big thing to explain. \nLDAP (Lightweight Directory Access Protocol; I don't know what the M means. Mobile ?) is an open, vendor-neutral, industry standard application \nprotocol for accessing and maintaining distributed directory information services over an IP network.\n#\nDirectory service refers to the collection of software, hardware, and processes that store and organize everyday items and network resources\n(folders, files, printers, users, groups, devices, telephone numbers...)\nIt looks like a database but it's different.\nThe thing that Directory service excels at is fast lookups for rarely changing data (email, username etc...)\nDifferences between database and Directory Service : https://www.c-sharpcorner.com/article/directory-services-vs-rdbms/\n#\nLDAP uses a relatively simple, string-based query to extract information from Active Directory. LDAP can store and extract objects such as usernames \nand passwords in Active Directory, and share that object data throughout a network. \nExample of LDAP usage : https://stackoverflow.com/questions/239385/what-is-ldap-used-for/592339\n\nI don't know why and how Samsung uses LDAP. This package, according to its name only does logging.\n",
+    "description": "MLDAP log\nLDAP (Lightweight Directory Access Protocol; I don't know what the M means. Mobile?) is an open, vendor-neutral, industry standard application protocol for accessing and maintaining distributed directory information services over an IP network.\nDirectory service refers to the collection of software, hardware, and processes that store and organize everyday items and network resources(folders, files, printers, users, groups, devices, telephone numbers...)\nIt looks like a database but it's different.\nDirectory services excel at fast lookups for rarely changing data (email, username etc...)\nDifferences between database and Directory Service : https://www.c-sharpcorner.com/article/directory-services-vs-rdbms/\nLDAP uses a relatively simple, string-based query to extract information from Active Directory. LDAP can store and extract objects such as usernames and passwords in Active Directory, and share that object data throughout a network. \nExample of LDAP usage : https://stackoverflow.com/questions/239385/what-is-ldap-used-for/592339\n\nI don't know why and how Samsung uses LDAP. This package, according to its name only does logging.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5681,7 +5681,7 @@
   {
     "id": "com.samsung.advp.imssettings",
     "list": "Oem",
-    "description": "Needed for VoLTE, a standard for high-speed wireless communication (https://en.wikipedia.org/wiki/Voice_over_LTE)\nIMS id an open industry standard for voice and multimedia communications over IP.\nNOTE: this package could be needed for messaging apps that sends SMS/RCS code to verify your phone number (see issue #17)\n",
+    "description": "Needed for VoLTE (Voice over LTE) https://en.wikipedia.org/wiki/Voice_over_LTE\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nNOTE: this package could be needed for messaging apps that send SMS/RCS code to verify your phone number (see issue #17)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5717,7 +5717,7 @@
   {
     "id": "com.samsung.android.app.aodservice",
     "list": "Oem",
-    "description": "Always On Display (https://play.google.com/store/apps/details?id=com.samsung.android.app.aodservice&hl=en)\nDisplays stuff when the screen is off (useless) but also handles the clock on the lockscreen.\n",
+    "description": "Always On Display\nNOTE: This package handles the clock on the lockscreen, in addition to the AOD functionality.\nWhen enabled in settings it shows clock and notifications when you raise the phone or touch the screen.\nThis is basically a lower-power lock-screen. It could in theory reduce power draw if you check notifications/clock often as OLED screens draw minimal power showing a mostly black screen(black = pixel off), but in practice the number of times you'll unintentionally trigger it will likely eat up any potential power savings and more. And if your device doesn't have an OLED screen this will draw way more power.\nMost of these power savings could be applied to your standard lock-screen simply by making your background image completely black.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5762,7 +5762,7 @@
   {
     "id": "com.sec.android.app.soundalive",
     "list": "Oem",
-    "description": "Responsible for Dobly Atmos and other pre-programmed equalizer stuff (accessible from the Settings app)\nNeeded by Adapt Sound (com.sec.hearingadjust) which a pretty useful but little known feature.\n",
+    "description": "Responsible for Dolby Atmos and other pre-programmed equalizer stuff (accessible from the Settings app)\nNeeded by Adapt Sound (com.sec.hearingadjust) which a pretty useful but little known feature.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -5888,7 +5888,7 @@
   {
     "id": "com.samsung.android.sm.devicesecurity",
     "list": "Oem",
-    "description": "Samsung Device security for the Smart Manager app using McAfee antivirus engine.\nThis is the antivirus in Settings -> Device care -> Security\nPrivacy nightmare (holy moly there is a LOT of permissions!) for a bit of security. \nhttps://www.hybrid-analysis.com/sample/05dab93ee2102a2fb6edf16e85750eb1f0189d7b82703c6a00c92cd08d62bb28?environmentId=200\nARCHIVE : https://web.archive.org/web/20200607140002/https://www.hybrid-analysis.com/sample/05dab93ee2102a2fb6edf16e85750eb1f0189d7b82703c6a00c92cd08d62bb28?environmentId=200\n\nThere is always a trade-off between security and privacy.\nSome people reported that without this package they weren't able to install apps anymore BUT I personnally removed this and\nI still can install apps.\nI think (but I'm not sure at all) that you can remove this safely if you also remove com.samsung.aasaservice and com.samsung.android.sm\n",
+    "description": "Samsung Device security for the Smart Manager app using McAfee antivirus engine.\nThis is the antivirus in Settings -> Device care -> Security\nPrivacy nightmare(LOTS of permissions!) for a bit of security.\nhttps://www.hybrid-analysis.com/sample/05dab93ee2102a2fb6edf16e85750eb1f0189d7b82703c6a00c92cd08d62bb28?environmentId=200\nARCHIVE: https://web.archive.org/web/20200607140002/https://www.hybrid-analysis.com/sample/05dab93ee2102a2fb6edf16e85750eb1f0189d7b82703c6a00c92cd08d62bb28?environmentId=200\n\nSome people reported that without this package they weren't able to install apps anymore BUT I personnally removed this and\nI still can install apps.\nI think(not sure) that you can remove this safely if you also remove com.samsung.aasaservice and com.samsung.android.sm",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6077,7 +6077,7 @@
   {
     "id": "com.sec.android.app.personalization",
     "list": "Oem",
-    "description": "Without a doubt this package is involved in personalization of something but tt's hard to find what.\n2 permissions : READ_PHONE_STATE and CHANGE_PHONE_STATE\n",
+    "description": "Has something to do with personalization?\nHas 2 permissions: READ_PHONE_STATE and CHANGE_PHONE_STATE",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6095,7 +6095,7 @@
   {
     "id": "com.sec.android.emergencylauncher",
     "list": "Oem",
-    "description": "Samsung Launcher when in emergency mode. \nHere, emergency = low battery\nSee below\n",
+    "description": "Samsung Launcher when in emergency(low battery) mode.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6122,7 +6122,7 @@
   {
     "id": "com.sec.android.emergencymode.service",
     "list": "Oem",
-    "description": "Emergency mode enables you to extend your device’s standby time when you are in an emergency situation and you want your device to \nconserve power for as long as possible. When this mode is activated, the screen’s brightness will decrease and some of  \nthe device's functionality will be limited in order to conserve your battery's charge. The home screen will be changed to a black theme \nto reduce battery consumption.\nIt is NOT related to SOS messages/911.\nhttps://www.samsung.com/uk/support/mobile-devices/what-is-emergency-mode/\n",
+    "description": "Emergency mode enables you to extend your device’s standby time when in an emergency situation and want your device to conserve power for as long as possible. When activated, screen brightness will decrease, some of functionality will be limited and the home screen is changed to a black theme, all to reduce battery drain (OLED screens draw less power when showing black, cuz black = pixel off).\nNOT related to SOS messages/911.\nhttps://www.samsung.com/uk/support/mobile-devices/what-is-emergency-mode/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6149,7 +6149,7 @@
   {
     "id": "com.samsung.android.honeyboard",
     "list": "Oem",
-    "description": "Samsung keyboard\nWARNING: do NOT remove the samsung keyboard if you don't have another keyboard with direct boot mode support or \nyou'll be stuck at boot (no keyboard to unlock the phone) \nhttps://developer.android.com/training/articles/direct-boot\nFYI: Simple Keyboard and OpenBoard are 2 FOSS keyboard with direct boot support\nhttps://f-droid.org/packages/org.dslul.openboard.inputmethod.latin/\nhttps://f-droid.org/packages/rkr.simplekeyboard.inputmethod/\nWARNING: Do NOT remove this package with root if it wasn't first uninstalled with the non-root method.\nWARNING: Removing this packages breaks the Accessibility settings on Android 11",
+    "description": "Samsung keyboard\nWARNING: do NOT disable if you don't have another keyboard with direct boot mode support, or you'll be stuck at boot (no keyboard to unlock the phone).\nhttps://developer.android.com/training/articles/direct-boot\nSimple Keyboard and OpenBoard are FOSS, based on the AOSP keyboard and have direct boot support:\nhttps://f-droid.org/packages/rkr.simplekeyboard.inputmethod/\nhttps://f-droid.org/packages/org.dslul.openboard.inputmethod.latin/\nWARNING: Do NOT remove this package with root if it wasn't first uninstalled with the non-root method.\nWARNING: Removing this packages breaks the Accessibility settings on Android 11.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6185,7 +6185,7 @@
   {
     "id": "com.sec.android.provider.emergencymode",
     "list": "Oem",
-    "description": "Provider for emergency mode (com.sec.android.emergencylauncher)\nReminder : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps.\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Provider for emergency mode (com.sec.android.emergencylauncher)\nContent providers encapsulate data, providing centralized management of data shared between apps.\nFor example: the Settings provider. It stores all the settings from your Settings app in a database, which apps can query for info on whether you for example have Dark Mode turned on or off.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6203,7 +6203,7 @@
   {
     "id": "com.sec.android.wallpapercropper2",
     "list": "Oem",
-    "description": "SOAgent\nResponsible for checking software/security OTA updates, readying, alerting the user and downloading such updates \nSoftware update, works along \"com.wssyncmldm\"\n\nSamsung Wallpaper. Needed to set a wallpaper on the launcher.\nNote : it is technically possible to change the wallpaper and then delete this package. \nUsed wallpaper are stored in /data/data/com.sec.android.wallpapercropper2/\n",
+    "description": "Samsung Wallpaper. Needed to set a wallpaper on the launcher.\nNote: it is possible to change the wallpaper and then disable this package.\nUsed wallpapers are stored in /data/data/com.sec.android.wallpapercropper2/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6212,11 +6212,11 @@
   {
     "id": "com.sec.imsservice",
     "list": "Oem",
-    "description": "This service allows calls and text messages to be delivered via an IP network (Volte/VoIP/Wifi calling). Video calling are obviously also concerned.\nNote : Samsung Dialer will crash if you delete this package and have wifi-calling activated in the Dialer's settings.\nMay be unsafe to uninstall it. I need some more testing.\n",
+    "description": "IMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nVideo calling is also affected.\nNote: Samsung Dialer will crash if you disable this package and have wifi-calling activated in the Dialer's settings.\nMay be unsafe to disable. Needs more testing.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.sec.automation",
@@ -6239,11 +6239,11 @@
   {
     "id": "com.sec.ims",
     "list": "Oem",
-    "description": "IMS is an open industry standard for voice and multimedia communications over packet-based IP networks (Volte/VoIP/Wifi calling).\nDon't really know the difference with com.sec.imsservice. Anyway, there is obviously strong interactions between them.\nMay be unsafe to uninstall it. I need some more testing.\n",
+    "description": "IMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nDon't know how this is different from com.sec.imsservice. Could they interact?\nMay be unsafe to disable. Needs more testing.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.sec.internal.vsim.VSimServiceApp",
@@ -6410,11 +6410,11 @@
   {
     "id": "com.android.bluetoothmidiservice",
     "list": "Aosp",
-    "description": "Provides classes for using the MIDI protocol over Bluetooth. Safe to remove if you don't plan to connect MIDI devices. \n(Seriously, use a PC if you want to do this !)\n",
+    "description": "Provides classes for using the MIDI protocol over Bluetooth. Safe to remove if you don't plan to connect MIDI devices.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.bookmarkprovider",
@@ -6423,39 +6423,39 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.carrierdefaultapp",
     "list": "Aosp",
-    "description": "Allows carrier customization. Carrier action upon specific signal.\n",
+    "description": "This package is a generic solution that allows carriers to indicate when a device has run OOB(Out Of Balance). Android devices that are OOB need carrier mitigation protocols to allow select data through(like to notify users their data/balance is out, or allow them to buy more data through the carrier app).\nWill probably break that functionality if disabled, but is otherwise safe to disable(should only affect users that are out of data/balance?).\nhttps://source.android.com/devices/tech/connect/oob-users",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.companiondevicemanager",
     "list": "Aosp",
-    "description": "Companion Device Manager that comes by default in every Oreo+ device. \nThis handles connections to other devices, like Bluetooth Headphones, desktop Operative Systems, ecc.\nOnly needed Google smart IoT devices (WearOS/Android Wear)\n",
+    "description": "Companion Device Manager\nThis handles connections to other devices, like Bluetooth Headphones, desktop Operating Systems, e.t.c.\nOnly needed for Google smart IoT devices (WearOS/Android Wear)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.dreams.basic",
     "list": "Aosp",
-    "description": "Daydream (not Google Daydream VR) is an interactive screensaver mode built into Android. \nWhen you dock your Android phone or tablet or charge it, its screen normally stays off. \nWhen you enable Daydream mode, the device’s screen will stay on and display the Daydream app you choose. \nYou can use this to display the time, weather, quotes, photos, news, tweets, or anything else that developers write a Daydream app for.\nhttps://developer.android.com/reference/android/service/dreams/DreamService\n",
+    "description": "Daydream (not Google Daydream VR) is an interactive screensaver mode built into Android.\nWith it turned on, it activates and shows the screensaver of your choice when you dock or charge your device.\nCan display the time, weather, quotes, photos, news, tweets, or anything else Daydream app developers can think of.\nhttps://developer.android.com/reference/android/service/dreams/DreamService",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.dreams.phototable",
     "list": "Aosp",
-    "description": "Photographic screensavers (Daydream stuff, see above)\n",
+    "description": "Photographic screensavers\nDaydream stuff, see com.android.dreams.basic",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6473,7 +6473,7 @@
   {
     "id": "com.android.egg",
     "list": "Aosp",
-    "description": "Android build's easter egg feature (when you click 5 times on the android version in the settings)\n",
+    "description": "Android's easter egg feature (spam-tap on the android version in the settings)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6491,11 +6491,11 @@
   {
     "id": "com.android.htmlviewer",
     "list": "Aosp",
-    "description": "In-built HTML viewer. Basically lets you read HTML files stored on your device.\nREMINDER : A web-browser can also read HTML files...\n",
+    "description": "Stock HTML viewer. Lets you open HTML files stored on your device.\nREMINDER: A web-browser can also read HTML files.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.magicsmoke",
@@ -6535,8 +6535,8 @@
   },
   {
     "id": "com.android.email.partnerprovider.overlay",
-    "list": "Aosp",
-    "description": "Lets Google partners (OEM in most cases) to customize the default email settings.\nThe manufacturer often change the default signature displayed the end of each of your mail (e.g \"Sent from my Nokia phone\")\n",
+    "list": "Pending",
+    "description": "Some overlay for partnerprovider?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6563,11 +6563,11 @@
   {
     "id": "com.android.simappdialog",
     "list": "Aosp",
-    "description": "Sim App Dialog\nUsed to install the carrier SIM app when the SIM is inserted.\n",
+    "description": "Sim App Dialog\nCreates a pop-up asking if the user wants to install the carrier app when a SIM is inserted. Seems to be event-triggered, i.e: doesn't run in the background.\nhttps://android.googlesource.com/platform/frameworks/base/+/master/packages/SimAppDialog/src/com/android/simappdialog/InstallCarrierAppActivity.java",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.soundrecorder",
@@ -6576,12 +6576,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.stk2",
     "list": "Aosp",
-    "description": "SIM toolkit app\nSpecial package for dual-sim devices?\nEnable carriers to make SIM cards initiate \"value-added services\" (== some crappy stuff)\nBasically, Some operators give SIMs which has applications installed in it. \nhttps://en.wikipedia.org/wiki/SIM_Application_Toolkit#cite_note-CellularZA-1\nHas already be abused : \n- SimJacker : https://thehackernews.com/2019/09/simjacker-mobile-hacking.html\n- WIBattack : https://www.zdnet.com/article/new-sim-card-attack-disclosed-similar-to-simjacker/\n",
+    "description": "SIM toolkit\nSpecial package for dual-sim devices?\nEnables carriers to initiate \"value-added services\". Basically, some operators provide SIM-cards with applications installed on them.\nhttps://en.wikipedia.org/wiki/SIM_Application_Toolkit#cite_note-CellularZA-1\nHas been abused:\n- SimJacker: https://thehackernews.com/2019/09/simjacker-mobile-hacking.html\n- WIBattack: https://www.zdnet.com/article/new-sim-card-attack-disclosed-similar-to-simjacker/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6590,7 +6590,7 @@
   {
     "id": "com.android.stk",
     "list": "Aosp",
-    "description": "SIM toolkit \nSIM toolkit app. Enable carriers to make SIM cards initiate \"value-added services\" (== some crappy stuff)\nBasically, Some operators give SIMs which has applications installed in it. \nhttps://en.wikipedia.org/wiki/SIM_Application_Toolkit#cite_note-CellularZA-1\nHas already be abused : \n- SimJacker : https://thehackernews.com/2019/09/simjacker-mobile-hacking.html\n- WIBattack : https://www.zdnet.com/article/new-sim-card-attack-disclosed-similar-to-simjacker/\n",
+    "description": "SIM toolkit\nEnables carriers to initiate \"value-added services\". Basically, some operators provide SIM-cards with applications installed on them.\nhttps://en.wikipedia.org/wiki/SIM_Application_Toolkit#cite_note-CellularZA-1\nHas been abused:\n- SimJacker: https://thehackernews.com/2019/09/simjacker-mobile-hacking.html\n- WIBattack: https://www.zdnet.com/article/new-sim-card-attack-disclosed-similar-to-simjacker/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6599,7 +6599,7 @@
   {
     "id": "com.android.traceur",
     "list": "Aosp",
-    "description": "System Tracing\nRecording device activity over a short period of time is known as system tracing. System tracing produces a trace file that can be used to generate a system report.\nNot useful if you're not a developer.\n",
+    "description": "System Tracing\nRecording device activity over a short period of time is known as system tracing. System tracing produces a trace file that can be used to generate a system report.\nNot useful if you're not a developer.\nhttps://developer.android.com/topic/performance/tracing",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6612,16 +6612,16 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.wallpaper.livepicker.overlay",
     "list": "Aosp",
-    "description": "Enables you to pick a live wallpaper.\n Removing it will break some weather applications (especially ones with widgets) and wallpaper applications like Muzei.",
+    "description": "Overlay for live wallpaper picker?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.wallpapercropper",
@@ -6639,7 +6639,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "android.auto_generated_vendor_",
@@ -6662,20 +6662,20 @@
   {
     "id": "com.android.apps.tag",
     "list": "Aosp",
-    "description": "Support for NFC tags interactions (5 permissions : Contacts/Phone On by default).\nNFC Tags are for instance used in bus to let you validate your transport card with your phone \nOther exemple : https://en.wikipedia.org/wiki/TecTile\nYou will still be able to connect to a NFC device (e.g a speaker) if removed.\n",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
-    "id": "com.android.backupconfirm",
-    "list": "Aosp",
-    "description": "Restore google settings with Google Backup restore function.\nAlso display confirmation popup when doing ADB backup. If you remove this package you couldn't do ADB Backup.\n",
+    "description": "Support for NFC tags interactions (5 permissions, Contacts/Phone On by default).\nNFC Tags are for instance used in buses to validate your transport card with your phone.\nOther exemple: https://en.wikipedia.org/wiki/TecTile\nYou will still be able to connect to a NFC device (e.g a speaker) with this disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Advanced"
+  },
+  {
+    "id": "com.android.backupconfirm",
+    "list": "Aosp",
+    "description": "Restores Google settings with Google Backup restore.\nDisplays confirmation popup when doing ADB backup. Disabling this package breaks ADB Backup.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.android.bio.face.service",
@@ -6716,7 +6716,7 @@
   {
     "id": "com.android.calendar",
     "list": "Aosp",
-    "description": "AOSP Calendar app\nNOTE: On some phones, Huawei & Xiaomi also use this package name for their own calendar app.\n",
+    "description": "AOSP Calendar app\nNOTE: Some OEMs (like Huawei & Xiaomi) use the same package name for their app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6725,7 +6725,7 @@
   {
     "id": "com.android.calculator2",
     "list": "Aosp",
-    "description": "AOSP calculator app.\nNOTE: On some phones, Huawei & Xiaomi also use this package name for their own calculator app.\n",
+    "description": "AOSP calculator app\nNOTE: Some OEMs (like Huawei & Xiaomi) use the same package name for their app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6734,16 +6734,16 @@
   {
     "id": "com.android.calllogbackup",
     "list": "Aosp",
-    "description": "Call Logs Backup/Restore feature.\nhttps://android.googlesource.com/platform/packages/providers/CallLogProvider/+/refs/heads/master/src/com/android/calllogbackup\n",
+    "description": "Call Logs Backup/Restore feature.\nRuns in the background.\nhttps://android.googlesource.com/platform/packages/providers/CallLogProvider/+/refs/heads/master/src/com/android/calllogbackup",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.android.captiveportallogin",
     "list": "Aosp",
-    "description": "Support for captive portal : https://en.wikipedia.org/wiki/Captive_portal\nA captive portal login is a web page where the users have to input their login information or accept the displayed terms of use. \nSome networks (typically public wifi network) use the captive portal login to block access until the user inputs \nsome necessary information\n",
+    "description": "Support for captive portal: https://en.wikipedia.org/wiki/Captive_portal\nA captive portal login is a web page where users have to log in or accept terms of use. Common for public wifi networks.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6752,7 +6752,7 @@
   {
     "id": "com.android.carrierconfig",
     "list": "Aosp",
-    "description": "Gives carriers and OEMs the ability to dynamically provide carrier configuration (APN settings) trough their app.\nNOTE : The probability that your carrier's APN change is very low. If you change your carrier and insert a new SIM card\nThis package will be triggered to automatically choose the suitable APN.\nhttps://source.android.com/devices/tech/config/carrier\nhttps://android.googlesource.com/platform/packages/apps/CarrierConfig/+/refs/heads/master/src/com/android/carrierconfig/DefaultCarrierConfigService.java\n",
+    "description": "Dynamically provides configuration for the carrier network.\nThe config contains: Roaming networks, Voicemail settings, SMS/MMS settings, VoLTE/IMS settings, and more.\nIf a carrier app is installed it will be queried for overrides to these settings.\nSeems to run on boot and when you swap SIM?\nhttps://source.android.com/devices/tech/config/carrier\nhttps://cs.android.com/android/platform/superproject/+/master:packages/apps/CarrierConfig/src/com/android/carrierconfig/DefaultCarrierConfigService.java",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6761,34 +6761,34 @@
   {
     "id": "com.android.cellbroadcastreceiver",
     "list": "Aosp",
-    "description": "Cell broadcast has been designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts. This package handles the situation on occurence of this event.\nRuns at boot time and is also triggered after exiting airplane mode.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know\nhttps://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver/+/refs/heads/master/src/com/android/cellbroadcastreceiver\n",
+    "description": "Cell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISPs to send Emergency/Government alerts.\nRuns at boot time and is also triggered after exiting airplane mode.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know\nhttps://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver/+/refs/heads/master/src/com/android/cellbroadcastreceiver",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.contacts",
     "list": "Aosp",
-    "description": "MIUI Contacts and dialer\nIt's the contacts app but you can access the dialer from this app.\n",
+    "description": "AOSP Contacts\nSome OEMs(for example Xiaomi) use the same package name for their app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.cts.priv.ctsshim",
     "list": "Aosp",
-    "description": "Compatibility Test Service. The CTS shim that verify certain upgrade scenarios. Could mess up witch OTA updates.\nhttps://android.googlesource.com/platform/frameworks/base/+/51e458e/packages/CtsShim\nhttps://en.wikipedia.org/wiki/Shim_(computing)\n",
+    "description": "Compatibility Test Service. Verifies certain upgrade scenarios. Disabling could mess with OTA updates.\nA shim is basically a compatibility layer for an API, that makes sure anything that uses the API does so correctly.\nhttps://android.googlesource.com/platform/frameworks/base/+/51e458e/packages/CtsShim\nhttps://en.wikipedia.org/wiki/Shim_(computing)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.deskclock",
     "list": "Aosp",
-    "description": "AOSP Clock app\nNOTE: On some phones Huawei & Xiaomi also use this package name for their own clock app.\n",
+    "description": "AOSP Clock app\nSome OEMs (like Huawei & Xiaomi) use the same package name for their app.\n",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6806,7 +6806,7 @@
   {
     "id": "com.android.emergency",
     "list": "Aosp",
-    "description": "Emergency informations. Safe to remove if you don't want this feature.\n",
+    "description": "Emergency rescue\nShows emergency info on lockscreen and power menu. Safe to disable if you don't want it.\nLoads on device unlock/lockscreen and power menu, so it's basically always cached in RAM, but shouldn't use much/any battery, so the main thing gained from disabling this package is the ~9MB RAM it uses.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6824,7 +6824,7 @@
   {
     "id": "com.android.facelock",
     "list": "Aosp",
-    "description": "Essential if you wanna use Face Unlock features, removable if you don't want to.\n",
+    "description": "Face Unlock\nSafe to remove if you don't use Face Unlock.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6833,7 +6833,7 @@
   {
     "id": "com.android.gallery3d",
     "list": "Aosp",
-    "description": "Xiaomi Gallery app (I'll stop repeating this is a really poor choice for the package name...)\n",
+    "description": "Xiaomi Gallery app",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6851,7 +6851,7 @@
   {
     "id": "com.android.inputdevices",
     "list": "Aosp",
-    "description": "Only contains a receiver named \"Android keyboard\", possibly for an external keyboard.\nLocates available keyboard layouts. \nAn application can offer additional keyboard layouts to the user by declaring a suitable broadcast receiver in its manifest.\n",
+    "description": "Only contains a receiver named \"Android keyboard\", possibly for an external keyboard.\nLocates available keyboard layouts. Apps can offer additional keyboard layouts to the user by declaring a suitable broadcast receiver in their manifest.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6860,7 +6860,43 @@
   {
     "id": "com.android.inputmethod.latin",
     "list": "Aosp",
-    "description": "AOSP keyboard. (This is not Google Keyboard).\n",
+    "description": "AOSP keyboard (not Google Keyboard)",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.display.cutout.emulation.corner",
+    "list": "Aosp",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.display.cutout.emulation.double",
+    "list": "Aosp",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.display.cutout.emulation.hole",
+    "list": "Aosp",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.display.cutout.emulation.noCutout",
+    "list": "Aosp",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6869,52 +6905,88 @@
   {
     "id": "com.android.internal.display.cutout.emulation.tall",
     "list": "Aosp",
-    "description": "Support for display cutouts\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts\n",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.display.cutout.emulation.waterfall",
+    "list": "Aosp",
+    "description": "Display cutout variant\nhttps://developer.android.com/guide/topics/display-cutout\nhttps://source.android.com/devices/tech/display/display-cutouts",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.android.internal.systemui.navbar.gestural",
     "list": "Aosp",
-    "description": "Gesture navigation\nLets you use swipes and other actions to control your phone, rather than tapping on buttons.\nOption -> System -> Gestures -> System Navigation\nhttps://android-developers.googleblog.com/2019/08/gesture-navigation-backstory.html\n",
+    "description": "Gesture navigation\nLets you use swipes and other actions to navigate your device, rather than buttons.\nhttps://android-developers.googleblog.com/2019/08/gesture-navigation-backstory.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.systemui.navbar.gestural_extra_wide_back",
+    "list": "Aosp",
+    "description": "Enables a setting increasing how far you need to move your finger to trigger the back gesture.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.systemui.navbar.gestural_narrow_back",
+    "list": "Aosp",
+    "description": "Enables a setting decreasing how far you need to move your finger to trigger the back gesture.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.android.internal.systemui.navbar.gestural_wide_back",
     "list": "Aosp",
-    "description": "Enables you to turn down the sensitivity to make it easier to perform gestures in apps (i.e. making back harder to trigger)\n",
+    "description": "Enables a setting increasing how far you need to move your finger to trigger the back gesture.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.internal.systemui.navbar.twobutton",
     "list": "Aosp",
-    "description": "",
+    "description": "Enables a setting for using just 2 buttons in the system navbar?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.internal.systemui.navbar.threebutton",
+    "list": "Aosp",
+    "description": "The default system navbar? It's what you use when you don't use gesture navigation.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.musicfx",
+    "list": "Aosp",
+    "description": "Audio EQ(equalizer). Some 3rd-party music apps can use it to provide you EQ features.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Advanced"
   },
   {
-    "id": "com.android.musicfx",
-    "list": "Aosp",
-    "description": "Audio equalizer. Some 3-party music apps can use it to provide you equalizing features.\n",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
     "id": "com.android.mms",
     "list": "Aosp",
-    "description": "AOSP SMS app.\nNOTE: On some phones, Huawei & Xiaomi also use this package name for their own SMS app.\n",
+    "description": "AOSP SMS app.\nOccasionally runs in the background.\nSome OEMs (like Huawei & Xiaomi) use the same package name for their app.\nQKSMS is a good FOSS replacement: https://f-droid.org/en/packages/com.moez.QKSMS/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6923,16 +6995,16 @@
   {
     "id": "com.android.nfc",
     "list": "Aosp",
-    "description": "NFC service\n",
+    "description": "NFC Service\nRuns in the background as part of the System.\nI assume NFC breaks when disabled.\nWill probably run even if disabled, like most system packages. So disabling/uninstalling is probably pointless.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.ons",
     "list": "Aosp",
-    "description": "Opportunistic Network Service\nOpportunistic networks are networks which are formed when devices come into contact opportunistically through \nphysical proximity, and communicate wirelessly to share each other’s content, resources and services.\nThis kind of networks leads to a set of challenging issues (congestion, transfer ordering, and resilience)\nBasically, this package implements ions (asynchronous networking) to resolve these issues.\nRun in background after booting the phone.\nhttps://en.wikipedia.org/wiki/Opportunistic_mobile_social_network\nSafe to remove if you want.\n",
+    "description": "Opportunistic Network Service\nFrom what I can glean in the source code it seems like this provides a list of available networks and assigns each network a priority.\nI've never seen it run on its own, so this might be part of some automatic network switching setting that I have turned off.\nhttps://cs.android.com/android/platform/superproject/+/master:packages/services/AlternativeNetworkAccess/src/com/android/ons/OpportunisticNetworkService.java\nhttps://developer.android.com/reference/android/telephony/AvailableNetworkInfo\nhttps://cs.android.com/android/platform/superproject/+/master:frameworks/base/telephony/java/android/telephony/AvailableNetworkInfo.java",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6941,16 +7013,16 @@
   {
     "id": "com.android.managedprovisioning",
     "list": "Aosp",
-    "description": "Manage separate profile on devices. \nThe typical example is setting up a corporate profile that is controlled by their employer on a users personal device \nto keep personal and work data separate.\nhttps://support.google.com/work/android/answer/6191949?\nhttps://developers.google.com/android/work/requirements/work-profile\nNeeded for sandbox's apps like Shelter/Island.\n",
+    "description": "Work Setup/Work profile setup\nManages Android user account profiles.\nThe typical use-case is setting up a corporate profile that is controlled by the employer on an employee's personal device, to keep personal and work data separate.\nhttps://support.google.com/work/android/answer/6191949?\nhttps://developers.google.com/android/work/requirements/work-profile\nNeeded for sandbox's apps like Shelter/Island.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.otaprovisioningclient",
     "list": "Aosp",
-    "description": "OTA Access Point Configuration\nOTA (Over the air : https://fr.wikipedia.org/wiki/Over-the-air_programming) is the method used by OEM to push updates on\nyour phone.\nAn OTA access point is used to run system software updates over a special gateway. This package is most likely customized\nby your OEM.\n",
+    "description": "OTA Access Point Configuration\nOTA (Over the air) is the method used by OEMs to push updates to your device.\nAn OTA access point is used to run system software updates over a special gateway. This package is most likely customized by your OEM.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6959,7 +7031,7 @@
   {
     "id": "com.android.pacprocessor",
     "list": "Aosp",
-    "description": "A PAC (Proxy Auto-Config) is a file which defines how an app can automatically define the correct proxy server for fetching an URL. \nShould be safe to remove if you don't use Auto-proxy (with PAC file config)\nhttps://en.wikipedia.org/wiki/Proxy_auto-config\n",
+    "description": "PAC (Proxy Auto-Config) is a file which defines how an app can automatically find the correct proxy server for fetching an URL.\nShould be safe to remove if you don't use Auto-proxy (with PAC file config)\nhttps://en.wikipedia.org/wiki/Proxy_auto-config",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -6968,34 +7040,34 @@
   {
     "id": "com.android.phone.recorder",
     "list": "Aosp",
-    "description": "AOSP Call recorder function. Most of the time OEM use their own code for this.\nNOTE: On some phones, Huawei & Xiaomi also use this package name for their own closed-source recorder app.\n",
+    "description": "AOSP Call recorder function. Most of the time OEM use their own code for this.\nNOTE: Some OEMs (like Huawei & Xiaomi) use the same package name for their app.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.android.printservice.recommendation",
+    "list": "Aosp",
+    "description": "I think this has to do with recommending a printservice app you can get from the Play store.\nI think printing still works with this off.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
-    "id": "com.android.printservice.recommendation",
-    "list": "Aosp",
-    "description": "Used to discover and interact one or more printers via one or more protocols. \nYou can remove it if you don't need to print directly from your phone.\n",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Advanced"
-  },
-  {
     "id": "com.android.printspooler",
     "list": "Aosp",
-    "description": "Print spooler. Manage the printing process. \nSafe to remove if you don't plan to print from your phone\nNote: Break connection preferences from the settings app on some phones (Pixel 4a / Android 11)\n",
+    "description": "Print Spooler\nManages the printing process.\nRuns on boot, but not beyond that.\nWARNING: Disabling breaks the connection preferences submenu in the settings app on most devices, but other than that it only breaks printing functionality and is safe to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.blockednumber",
     "list": "Aosp",
-    "description": "Handles blocked numbers storage\nOn some devices this packages seems to be tied to recent apps menu (see https://gitlab.com/W1nst0n/universal-android-debloater/-/issues/6)\n",
+    "description": "Handles blocked number storage.\nOn some devices this seems to be tied to the recent apps menu (see https://gitlab.com/W1nst0n/universal-android-debloater/-/issues/6)\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7004,25 +7076,25 @@
   {
     "id": "com.android.providers.calendar",
     "list": "Aosp",
-    "description": "Necessary to sync stock Calendar app and lets it work correctly.\n",
+    "description": "Calendar Storage\nNecessary for the stock Calendar app to work correctly.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.providers.drm",
     "list": "Aosp",
-    "description": "DRM Protected Content Storage \nProvides DRM functions to stop you from copying things like ringtones, live wallpapers, etc.\nMay be needed to access media files (to be verified)\n",
+    "description": "DRM Protected Content Storage\nManages DRM storage on the device?\nProbably required for some forms of DRM; disabling might break things like Netflix streaming, which relies on DRM to function.\nhttps://en.wikipedia.org/wiki/Digital_rights_management",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.providers.userdictionary",
     "list": "Aosp",
-    "description": "Handles user dictionary for keyboard apps. \n",
+    "description": "Handles user dictionary for keyboard apps.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7031,7 +7103,7 @@
   {
     "id": "com.android.proxyhandler",
     "list": "Aosp",
-    "description": "Handles proxy config\nSafe to remove if you don't use a proxy.\n",
+    "description": "Handles proxy config.\nSafe to remove if you don't use a proxy.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7049,25 +7121,25 @@
   {
     "id": "com.android.se",
     "list": "Aosp",
-    "description": "Underlying implementation for Open Mobile API SEService (OMAPI SE)\nEnables apps to use the OMAPI API to access secure elements (SE) to enable smart-card payments and other secure services.\n\nA SE is a special chip (e.g SIM-card) whose the main purpose is to store cryptographic secrets in such a way \nthat illicit use is hard or impossible to do.\n#\nFYI : The Open Mobile Alliance (OPA) is a standards organization which develops open standards for the mobile phone industry.\n",
+    "description": "SecureElementApplication\nRuns in the background as part of the system.\nUnderlying implementation for the OMAPI SE service.\nEnables apps to use the OpenMobile API to access secure elements(SE) to enable smart-card payments and other secure services.\n\nAn SE is a special chip (e.g SIM-card) for storing cryptographic secrets in a way that makes illicit use hard.\nThe Open Mobile Alliance (OPA) is a standards organization which develops open standards for the mobile phone industry.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.settings.intelligence",
     "list": "Aosp",
-    "description": "Setting search feature \nNote: Settings app may crash when searching for a setting if you removed this package (it depends on the phone)\nSee https://gitlab.com/W1nst0n/universal-android-debloater/-/issues/51\n",
+    "description": "Settings Suggestions\nHandles the search and suggestions features in the settings app.\nDisabling this package makes the Settings app crash when you tap on search.\nDoesn't run in the background, so there's little benefit in disabling.\nhttps://gitlab.com/W1nst0n/universal-android-debloater/-/issues/51",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.sharedstoragebackup",
     "list": "Aosp",
-    "description": "Used during backup. Fetch shared storage (files accessible by every apps with STORAGE permission)\nThings have changed with Android 10. Don't know if this package is still relevant for new phones.\nhttps://blog.mindorks.com/understanding-the-scoped-storage-in-android.\n",
+    "description": "Used during backup. Backs up the shared storage? (files accessible by every app with STORAGE permission)\nThings have changed with Android 10. Don't know if this package is still relevant for new phones.\nhttps://blog.mindorks.com/understanding-the-scoped-storage-in-android.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7076,11 +7148,20 @@
   {
     "id": "com.android.smspush",
     "list": "Aosp",
-    "description": "This service is used to push/send specially formatted SMS messages that display an alert message to the user, \nand give the user the option of connecting directly to a particular app.\nFor instance, a SMS notifying the user he as a new e-mail, with a URL link to connect directly to the e-mail application\nhttps://web.archive.org/web/20200915164901/https://www.nowsms.com/doc/submitting-sms-messages/sending-wap-push-messages\n",
+    "description": "This service is used to push/send specially formatted SMS messages that display an alert message to the user, and give them the option of connecting directly to a particular app.\nFor instance, an SMS notifying the user of a new e-mail, with a URL link to connect directly to the e-mail app.\nhttps://web.archive.org/web/20200915164901/https://www.nowsms.com/doc/submitting-sms-messages/sending-wap-push-messages",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Advanced"
+  },
+  {
+    "id": "com.android.systemui.plugin.globalactions.wallet",
+    "list": "Google",
+    "description": "Apk file name: QuickAccessWallet\nThis is the Google Pay widget in the power menu(hold power button for 1sec to show this menu), below the Emergency, Power off and Reboot buttons.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
   },
   {
     "id": "com.android.systemui.theme.dark",
@@ -7139,7 +7220,7 @@
   {
     "id": "com.android.webview",
     "list": "Aosp",
-    "description": "AOSP webview\nIt's a system component for the Android operating system (OS) that allows Android apps to display content \nfrom the web directly inside an application. \nThis package is no longer used in recent phones as it was replaced by com.google.android.webview\n#\nOn open-source privacy oriented Webview is Bromite (https://www.bromite.org/system_web_view)\n)\n",
+    "description": "AOSP webview\nDeprecated and replaced by com.google.android.webview\nAllows Android apps to display content from the web directly inside the app. It's based on Chrome.\nBromite is an open-source, privacy-oriented Webview replacement: https://www.bromite.org/system_web_view",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7148,7 +7229,7 @@
   {
     "id": "com.android.certinstaller",
     "list": "Aosp",
-    "description": "Certificate installer. Identifies your device and confirms that it should be able to access something.\nHere it is used for accepting and revoking of Internet certificates. Break wifi if removed.\n",
+    "description": "Certificate installer\nUsed for accepting and revoking Internet certificates.\nCertificates identify ownership of public keys, for use in secure communications.\nBreaks Wi-Fi if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7157,7 +7238,7 @@
   {
     "id": "com.android.defcontainer",
     "list": "Aosp",
-    "description": "Package Access Helper \nDetermine the recommended install location for packages and if there is enough free space for the package.\n",
+    "description": "Package Access Helper\nDetermine the recommended install location for packages and if there is enough free space for the package.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7166,25 +7247,25 @@
   {
     "id": "com.android.documentsui",
     "list": "Aosp",
-    "description": "Interface for apps wishing to access access files outside of their own storage area.\n",
+    "description": "Same as com.google.android.documentsui? Here's that description:\nFiles\nOccasionally runs in the background.\nFile selector for other apps. Another file browser can replace most of the functionality, but not all apps support that.\nSafe to disable, but will of course break file saving/loading functionality for some apps.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.android.documentsui.a_overlay",
     "list": "Aosp",
-    "description": "DocumentsUI Overlay\nThe DocumentsUI controls access to specific files for components that handle document permissions \n(such as attaching a file to an email)\nhttps://source.android.com/devices/architecture/modular-system/documentsui?hl=en\n",
+    "description": "Some overlay for for \"Files\"?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.android.dynsystem",
     "list": "Aosp",
-    "description": "Dynamic System Updates\nTreble gived the ability to boot an AOSP Generic System Image (GSI) on any supported device. \nDynamic System Updates allows to boot into a Generic System Image (GSI) without interfering with the current installation.\nThat means the bootloader doesn’t need to be unlocked and the user data doesn’t need to be wiped.\nhttps://developer.android.com/topic/dsu\n",
+    "description": "Dynamic System Updates\nRuns on boot, but doesn't seem to run in the background beyond that.\nTreble gives the ability to boot an AOSP Generic System Image (GSI) on any supported device.\nDynamic System Updates allows to boot into a Generic System Image (GSI) without interfering with the current installation.\nThat means the bootloader doesn’t need to be unlocked and the user data doesn’t need to be wiped.\nhttps://developer.android.com/topic/dsu",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7193,11 +7274,11 @@
   {
     "id": "com.android.externalstorage",
     "list": "Aosp",
-    "description": "Needed by apps to access external storage (SD card)\n",
+    "description": "Needed by apps to access external storage (like memory cards).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.android.keychain",
@@ -7211,7 +7292,7 @@
   {
     "id": "com.android.localtransport",
     "list": "Aosp",
-    "description": "Backup transport for stashing stuff into a known location on disk, and later restoring from there.\nSeems needed for storeing backup data locally on the device. \nThis package also provides the backup confirmation UI.\nhttps://developer.android.com/guide/topics/data/testingbackup\n",
+    "description": "Backup transport for stashing stuff into a known location on disk, and later restoring from there.\nNeeded for storing backup data locally on a device?\nThis package also provides the backup confirmation UI.\nhttps://developer.android.com/guide/topics/data/testingbackup",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7220,7 +7301,7 @@
   {
     "id": "com.android.location.fused",
     "list": "Aosp",
-    "description": "Manages the underlying location technologies, such as GPS and Wi-Fi.\n",
+    "description": "Manages underlying location technologies, such as GPS and Wi-Fi.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7238,7 +7319,7 @@
   {
     "id": "com.android.mtp",
     "list": "Aosp",
-    "description": "MTP Host\nHandles MTP (protocol allowing files to be transferred to and from your PC)\n",
+    "description": "MTP Host\nHandles MTP(Media Transfer Protocol), a protocol for transfering files between the device and a connected PC.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7265,7 +7346,7 @@
   {
     "id": "com.android.phone.a_overlay",
     "list": "Aosp",
-    "description": "AOSP code for dialer app features\nSIM card will also not be detected if deleted.\n",
+    "description": "AOSP code for dialer app features.\nSIM card will not be detected if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7274,7 +7355,7 @@
   {
     "id": "com.android.providers.applications",
     "list": "Aosp",
-    "description": "Fetches the list of applications installed on the phone to provide search suggestions.\n",
+    "description": "Provides a list of installed applications.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7283,16 +7364,16 @@
   {
     "id": "com.android.providers.contacts",
     "list": "Aosp",
-    "description": "Handle interaction with contacts data\n",
+    "description": "Contacts Storage\nProvider for contact data.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html\nBreaks contact functionality if disabled. Not recommended to disable if you plan to use your device as a phone.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.downloads",
     "list": "Aosp",
-    "description": "Provider for downloads manager.\n",
+    "description": "Downloads Manager\nProvider for downloaded files.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7301,7 +7382,7 @@
   {
     "id": "com.android.providers.downloads.ui",
     "list": "Aosp",
-    "description": "User interface for listing downloads.\n",
+    "description": "Downloads\nUser interface for downloads.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7310,16 +7391,16 @@
   {
     "id": "com.android.providers.media",
     "list": "Aosp",
-    "description": "Handle access to media files.\n",
+    "description": "Provider of media files (images, videos and such).\nScans the device for media files and allows permitted apps access to them.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.settings",
     "list": "Aosp",
-    "description": "Handles settings app datas (contentProvider)\nhttps://android.stackexchange.com/questions/37195/why-are-there-two-settings-apps-settings-and-settings-storage\n",
+    "description": "Provider for settings app data.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7328,7 +7409,16 @@
   {
     "id": "com.android.providers.telephony",
     "list": "Aosp",
-    "description": "Telephony provider. Controls and stores phone-related data such as text messages, APN list, operation, etc.\n",
+    "description": "Provider for telephony data.\nHandles phone-related data such as text messages, APN list, e.t.c.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.android.server.telecom",
+    "list": "Aosp",
+    "description": "Manages calls via your network provider or SIM and controls the phone modem?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7337,7 +7427,7 @@
   {
     "id": "com.android.server.telecom.a_overlay",
     "list": "Aosp",
-    "description": "Management your calls via your network provider or SIM and controls the phone modem.\n",
+    "description": "Overlay for com.android.server.telecom?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7346,7 +7436,7 @@
   {
     "id": "com.android.settings",
     "list": "Aosp",
-    "description": "AOSP Settings app features\n",
+    "description": "AOSP Settings app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7355,7 +7445,7 @@
   {
     "id": "com.android.shell",
     "list": "Aosp",
-    "description": "Unix shell to communicate via ADB commands through PC.\n",
+    "description": "Shell\nUnix shell that receives ADB commands sent from a PC.\nThis is what UAD uses to execute commands on Android devices. Proobably a bad idea to disable ;)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7364,7 +7454,7 @@
   {
     "id": "com.android.statementservice",
     "list": "Aosp",
-    "description": "Intent Filter Verification Service\nIntent : https://developer.android.com/reference/android/content/Intent\nIntent Filters : https://developer.android.com/guide/components/intents-filters\nhttps://android.stackexchange.com/questions/191163/what-does-the-intent-filter-verification-service-app-from-google-do\n",
+    "description": "Intent Filter Verification Service\nIntent: https://developer.android.com/reference/android/content/Intent\nIntent Filters: https://developer.android.com/guide/components/intents-filters\nhttps://android.stackexchange.com/questions/191163/what-does-the-intent-filter-verification-service-app-from-google-do",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7395,12 +7485,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
   },
   {
     "id": "cn.oneplus.photos",
     "list": "Oem",
-    "description": "Shot On OnePlus\nAccessible through the Wallpapers selection menu.\nProvide photos uploaded by OnePlus users, allowing you to set them as your current wallpaper. \nEach day, one new photo appears within the application.\n",
+    "description": "Shot On OnePlus\nAccessible through the Wallpapers selection menu.\nProvides photos uploaded by OnePlus users, allowing you to set them as your wallpaper.\nEach day, one new photo appears within the application.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7418,11 +7508,20 @@
   {
     "id": "com.fingerprints.fingerprintsensortest",
     "list": "Oem",
-    "description": "Sensor Test Tool \nProvide fingerprint hidden test menu (type *#806 in OnePlus dialer)\n",
+    "description": "Sensor Test Tool\nProvides hidden fingerprint test menu. Type *#806 in OnePlus dialer to open.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.fingerprints.serviceext",
+    "list": "Pending",
+    "description": "Handles fingerprint authentication?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.oem.autotest",
@@ -7436,7 +7535,7 @@
   {
     "id": "com.oem.logkitsdservice",
     "list": "Oem",
-    "description": "Used by a Shady logging app (com.oem.oemlogkit) which can be activated a bit too easily.\nNo good reason why this app is on customer devices.\nIt can log WiFi traffic, Bluetooth traffic, NFC activity, GPS coordinates over time, power consumption, modem signal/data details, \"lag issues,\" and more.\nhttps://thehackernews.com/2017/11/oneplus-logkit-app.html\nhttps://www.bleepingcomputer.com/news/security/second-oneplus-factory-app-discovered-this-one-dumps-photos-wifi-and-gps-logs/\nSource : https://nitter.net/fs0c131y/status/930773795656396801\n",
+    "description": "Used by com.oem.oemlogkit, a shady logging app.\nDoesn't run by default, but can easily be triggered by system apps.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7454,7 +7553,7 @@
   {
     "id": "com.oem.oemlogkit",
     "list": "Oem",
-    "description": "OnePlusLogKit \nSee \"com.oem.logkitsdservice\"\n",
+    "description": "OnePlus LogKit\nShady logging app that system apps can use to log WiFi traffic, Bluetooth traffic, NFC activity, GPS coordinates over time, power consumption, modem signal/data details, \"lag issues,\" and more.\nhttps://thehackernews.com/2017/11/oneplus-logkit-app.html\nhttps://www.bleepingcomputer.com/news/security/second-oneplus-factory-app-discovered-this-one-dumps-photos-wifi-and-gps-logs/\nhttps://nitter.net/fs0c131y/status/930773795656396801",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7463,7 +7562,7 @@
   {
     "id": "com.oneplus.backuprestore",
     "list": "Oem",
-    "description": "OnePlus Switch (https://play.google.com/store/apps/details?id=com.oneplus.backuprestore)\nLets you migrate your contacts, text messages, photos, and other data from your previous phone to a OnePlus phone. \nIt can also help backup your data of the OnePlus phone as a compressed archive.\n",
+    "description": "OnePlus Switch (https://play.google.com/store/apps/details?id=com.oneplus.backuprestore)\nLets you migrate contacts, text messages, photos, and other data from one device to another.\nCan also backup data as a compressed archive.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7472,7 +7571,7 @@
   {
     "id": "com.oneplus.brickmode",
     "list": "Oem",
-    "description": "OnePlus Zen Mode (https://play.google.com/store/apps/details?id=com.oneplus.brickmode)\nZen Mode will help you put down your phone and enjoy your life.\nIn Zen Mode you will only be able to take photos and answer calls.\n",
+    "description": "OnePlus Zen Mode (https://play.google.com/store/apps/details?id=com.oneplus.brickmode)\nZen Mode helps you put down your phone and enjoy your life.\nIn Zen Mode you will only be able to take photos and answer calls.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7490,16 +7589,124 @@
   {
     "id": "com.oneplus.card",
     "list": "Oem",
-    "description": "Card Package\nWidget which lets you add membership card in Shelf.\nYou enter numbers for a club card or something and it'll store it and generate a barcode for you.\n#\nNote : Shelf is essentially a page on your home screen that allows you to take memos, add widgets, gain access to your most-used apps, \nand get a quick glimpse of the weather. Swipe right (from the left edge of your OnePlus screen) and you'll see Shelf in action.\n",
+    "description": "Card Package\nWidget which lets you add membership card in Shelf.\nYou enter numbers for a club card or something and it'll store it and generate a barcode for you.\nShelf is a page on your home screen that allows you to take memos, add widgets, gain access to your most-used apps, and get a quick glimpse of the weather. Swipe right (from the left edge of your home screen) to reveal it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
+    "id": "com.oneplus.carrierlocation",
+    "list": "Oem",
+    "description": "Carrier Location Access\nRuns on boot, but not in the background beyond that.\nNot sure what this does. Could be related to detecting region to determine which radio frequencies to use?\nNoticed no ill effects from weeks of having it disabled.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.android",
+    "list": "Oem",
+    "description": "Android System Theme pack",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.android.networkstack.inprocess",
+    "list": "Oem",
+    "description": "Theming for Android system parts?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.android.networkstack.inprocess.cn",
+    "list": "Oem",
+    "description": "Theming for Android system parts?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.android.systemui",
+    "list": "Oem",
+    "description": "System UI Theme pack\nGuessing it's a pack of themes for some Oneplus-specific system component, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.android.wifi.resources",
+    "list": "Oem",
+    "description": "System Wi-Fi resources Theme pack\nGuessing it's a pack of themes for some Wi-Fi related system UI, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.google.android.networkstack",
+    "list": "Oem",
+    "description": "Network manager Theme pack\nThe package name is pretty self-explanatory.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.google.android.networkstack.cn",
+    "list": "Oem",
+    "description": "Network manager Theme pack\nThe package name is pretty self-explanatory.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.commonoverlay.com.oneplus",
+    "list": "Oem",
+    "description": "Oneplus System Theme pack\nGuessing it's a pack of themes for Oneplus-specific system components, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.communication.data",
+    "list": "Oem",
+    "description": "Communication important data\nOdd name. No idea what it does.\nContains the \"OPRecorderService\", but I've never seen it run. Also contains a \"OneplusAuthorizationActivity\" that doesn't seem to do anything when activated.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.oneplus.cota",
+    "list": "Oem",
+    "description": "Carrier Update\nRuns in the background.\ncota = Carrier OTA. Handles carrier-specific OTA updates? Probably safe to disable if you didn't get your phone from a carrier; the normal System Update(com.oneplus.opbackup) should handle the OTA updates. I can confirm that I got an OTA notification even with this disabled.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.engmode",
+    "list": "Oem",
+    "description": "Some kind of Engineer mode? I've no clue.\nContains a bunch of activities with \"info\" in their names.\nContains an \"OpFloatViewService\", but I've never seen it run.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "com.oneplus.factorymode",
     "list": "Oem",
-    "description": "EngineeringMode/ FactoryMode\nUsed by the operator in the factory to test the devices.\nYou only need to type *#808in the OnePlus dialer to acess the hidden menu.\nPotential security risk : https://nitter.net/fs0c131y/status/930115188988182531\nIt's now possible for an app to enable root access on any device with the APK preinstalled. \nFor now, this only works in ADB, which requires local access to the device.\n#\nOnePlus decided to remove this app.\n",
+    "description": "FactoryMode\nUsed in the factory to test devices.\nType *#808in the OnePlus dialer to acess the hidden menu.\nPotential security risk: https://nitter.net/fs0c131y/status/930115188988182531\nIt's possible for an app to enable root access on any device with the APK preinstalled.\nFor now, this only works in ADB, which requires local access to the device.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7508,7 +7715,7 @@
   {
     "id": "com.oneplus.factorymode.specialtest",
     "list": "Oem",
-    "description": "Engineering Mode Special Test\nUsed by the operator in the factory to test the devices.\n#\nSee above.\n",
+    "description": "Engineering Mode Special Test\nUsed in the factory to test devices.\nSee com.oneplus.factorymode",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7517,7 +7724,7 @@
   {
     "id": "com.oneplus.gamespace",
     "list": "Oem",
-    "description": "OnePlus Game Space\nUseless. Game launcher.\nAllows you to launch your game library as well as checking out several stats about the game, such as how long you have played.\n",
+    "description": "OnePlus Game Space\nOccasionally runs in the background as part of the system.\nAllows you to launch your game library, check game stats(such as playtime) and activate game overlay features.\nThis is the only way to access the recording buffer functionality (records the last X seconds into RAM and saves them when you tap save), so keep enabled if you need that or any of the other features.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7530,30 +7737,75 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.opbugreportlite",
     "list": "Oem",
-    "description": "OPBugReportLite \nSends silently, every 6 hours, the battery stats, kernel panics, watchdogs, ANRs and all crashes of your device to Singapore.\nhttps://www.androidpit.com/oneplus-opbugreportlite-data-collection\nSource (yeah it's Elliot Alderson again :D) : https://nitter.net/fs0c131y/status/933037531066785797\n",
+    "description": "OPBugReportLite\nRuns in the background. Runs as part of the system, even if disabled? Disabling does remove all RAM usage tho, and hopefully removes access to user data, as disable/uninstall should sever the connection to the Android user account.\nSilently sends, every 6 hours, battery stats, kernel panics, watchdogs, ANRs and all crashes of your device to Singapore.\nhttps://www.androidpit.com/oneplus-opbugreportlite-data-collection\nSource (yeah it's Elliot Alderson again :D): https://nitter.net/fs0c131y/status/933037531066785797",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.oneplus.productoverlay.android",
+    "list": "Oem",
+    "description": "Android System Theme pack\nGuessing it's a pack of themes for some Android System component, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.productoverlay.com.oneplus",
+    "list": "Oem",
+    "description": "Oneplus System Theme pack\nGuessing it's a pack of themes for Oneplus-specific system components, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.productoverlay.com.android.providers.settings",
+    "list": "Oem",
+    "description": "Settings Storage Theme pack\nGuessing it's a pack of themes for Settings Storage, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.providers.media",
+    "list": "Oem",
+    "description": "OnePlus Media Storage\nRuns in the background.\nSeems to just add recycle bin functionality to your file management (file browsers). Keep enabled if you like that function. But safe to disable if you don't want it.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.oneplus.skin",
+    "list": "Pending",
+    "description": "",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.oneplus.soundrecorder",
     "list": "Oem",
-    "description": "OnePlus voice recording app \n",
+    "description": "Recorder\nOnePlus sound recording app.\nRequires turning on \"Allow modifying system settings\" to use for some reason? Probably tied to recording phone-calls.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.tencent.soter.soterserver",
     "list": "Oem",
-    "description": "Soter is a biometric authentication standard and platform in Android held by Tencent.\nhttps://github.com/Tencent/soter#a-quick-look-at-tencent-soter\nFYI : Tencent is a Chinese multinational conglomerate holding company (https://en.wikipedia.org/wiki/Tencent#Controversies)\n",
+    "description": "Soter is a biometric authentication standard and platform by Tencent.\nhttps://github.com/Tencent/soter\nProvides biometric authentication for WeChat Pay. Safe to disable if you don't use it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7562,7 +7814,7 @@
   {
     "id": "com.wapi.wapicertmanage",
     "list": "Oem",
-    "description": "WAPI certificate manager\nWAPI = WLAN Authentication and Privacy Infrastructure. \nIt's a Chinese National Standard for Wireless LAN (local area network : within a limited area such as a home)\nNot very useful if you don't live in China.\nFYI : https://en.wikipedia.org/wiki/WLAN_Authentication_and_Privacy_Infrastructure\n#\nDigital certificates identify computers, phones, and apps for security. Just like you'd use your driver’s license \nto show that you can legally drive, a digital certificate identifies your device and confirms that it should be able to access something.\nFYI : https://security.stackexchange.com/questions/102550/what-are-wifi-certificates-used-for-what-are-they \n",
+    "description": "WAPI certificate manager\nWAPI = WLAN Authentication and Privacy Infrastructure.\nA Chinese national standard for Wireless LAN within a limited area such as a home. Not very useful if you don't live in China.\nhttps://en.wikipedia.org/wiki/WLAN_Authentication_and_Privacy_Infrastructure\nDigital certificates identify devices and apps for security. Just like your driver’s license shows that you can legally drive, a digital certificate identifies your device and confirms that it should be able to access something.\nhttps://security.stackexchange.com/questions/102550/what-are-wifi-certificates-used-for-what-are-they",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7571,7 +7823,7 @@
   {
     "id": "net.oneplus.commonlogtool",
     "list": "Oem",
-    "description": "OnePlus Common Log Tool\n9 permissions and given what we know about OnePlus logging apps, it's a good idea to remove this \nSee \"com.oneplus.opbugreportlite\", \"com.oneplus.factorymode\", \"com.oem.logkitsdservice\".\n",
+    "description": "OnePlus Common Log Tool\n9 permissions and given what we know about OnePlus logging apps, it's a good idea to disable this.\nSee com.oneplus.opbugreportlite, com.oem.oemlogkit and net.oneplus.odm",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7580,7 +7832,7 @@
   {
     "id": "net.oneplus.forums",
     "list": "Oem",
-    "description": "OnePlus Community (https://play.google.com/store/apps/details?id=net.oneplus.forums)\nLets you access to OnePlus forum... wah that great !\n",
+    "description": "OnePlus Community (https://play.google.com/store/apps/details?id=net.oneplus.forums)\nLiterally just their forum... in an app.\nJust use a Browser if you wanna access the forums.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7589,16 +7841,25 @@
   {
     "id": "com.oneplus.opsports",
     "list": "Oem",
-    "description": "Cricket Scores (https://play.google.com/store/apps/details?id=com.oneplus.opsports)\nLets you access and follow cricket teams and tournaments\n",
+    "description": "Cricket Scores (https://play.google.com/store/apps/details?id=com.oneplus.opsports)\nLets you access and follow cricket teams and tournaments.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
+    "id": "com.oneplus.orm",
+    "list": "Oem",
+    "description": "Seems to be Oneplus' Memory Management System according to a press-kit/-release they made for Android 11 (multiple sites wrote \"ORM Memory Management System\" word-for-word).\nRuns in the background as part of the system. Runs even if disabled? Doesn't use any RAM when disabled tho, vs ~50MB when enabled.\nSeems safe to disable, haven't noticed any negative effects in weeks of use, but I assume it breaks the \"RAM Boost\" feature (which is pointless anyway IMO).\nApk file name: OPOmm, mm = Memory Management?\nHas 2 permissions: KILL_BACKGROUND_PROCESSES and SET_TIME_ZONE.\nContains 2 services: OPManagerService and BackgroundCollectorService.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
     "id": "net.oneplus.odm.provider",
     "list": "Oem",
-    "description": "Shady analytic app... again.\nSends A LOT of data to OnePlus' servers including the phone's IMEI number, the phone number, MAC addresses, \nmobile network names and IMSI prefixes, Wi-Fi connection info, the phone's serial number and every time an app was opened.\nPress : https://www.androidpolice.com/2017/10/10/never-settle-oneplus-found-collecting-personally-identifiable-analytics-data-phone-owners/\nSource : https://www.chrisdcmoore.co.uk/post/oneplus-analytics/\n",
+    "description": "Insight Provider\nProvider for net.oneplus.odm? (shady telemetry app)\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7607,7 +7868,7 @@
   {
     "id": "net.oneplus.odm",
     "list": "Oem",
-    "description": "Shady analytic app... again.\nSends A LOT of data to OnePlus' servers including the phone's IMEI number, the phone number, MAC addresses, \nmobile network names and IMSI prefixes, Wi-Fi connection info, the phone's serial number and every time an app was opened.\nPress : https://www.androidpolice.com/2017/10/10/never-settle-oneplus-found-collecting-personally-identifiable-analytics-data-phone-owners/\nSource : https://www.chrisdcmoore.co.uk/post/oneplus-analytics/\n",
+  "description": "\"OnePlus System Service\"\nShady telemetry app.\nSends loads of data to OnePlus' servers, including IMEI, phone number, MAC addresses, mobile network names and IMSI prefixes, Wi-Fi connection info, the phone's serial number and every time an app was opened.\nSource: https://www.chrisdcmoore.co.uk/post/oneplus-analytics/\nPress: https://www.androidpolice.com/2017/10/10/never-settle-oneplus-found-collecting-personally-identifiable-analytics-data-phone-owners/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7616,7 +7877,7 @@
   {
     "id": "net.oneplus.provider.appcategoryprovider",
     "list": "Oem",
-    "description": "AppCategoryProvider\nUsed to regroup app in category in the OnePlus launcher ?\n",
+    "description": "AppCategoryProvider\nRuns in the background.\nI think this categorizes apps for use with system functionality, for example: automatically adding games to Game Mode.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7625,16 +7886,25 @@
   {
     "id": "net.oneplus.push",
     "list": "Oem",
-    "description": "OnePlus push notification. \nIt only concern OnePlus useless preinstalled apps (\"surveys and other junks\" according a user)\nhttps://forums.oneplus.com/threads/psa-non-root-root-stop-oneplus-push-notifications.580058/\nOnePlus can remotely sends you push notification :\nhttps://www.androidpolice.com/2019/07/01/oneplus-accidentally-pushed-a-cryptic-notification-to-all-7-pro-users/\n",
+    "description": "Push\nOnePlus push notifications.\nOnly used by OnePlus' preinstalled apps. Pushes \"surveys and other junk\" according a user.\nhttps://forums.oneplus.com/threads/psa-non-root-root-stop-oneplus-push-notifications.580058/\nOnePlus can remotely send push notifications:\nhttps://www.androidpolice.com/2019/07/01/oneplus-accidentally-pushed-a-cryptic-notification-to-all-7-pro-users/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
+    "id": "net.oneplus.wallpaperresources",
+    "list": "Oem",
+    "description": "Resources for some live wall papers? Not sure.\nOnly contains a \"WallpaperResourceProvider\", no services, activities or receivers.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "net.oneplus.weather",
     "list": "Oem",
-    "description": "OnePlus weather app (https://play.google.com/store/apps/details?id=net.oneplus.weather)\n",
+    "description": "OnePlus Weather (https://play.google.com/store/apps/details?id=net.oneplus.weather)\nOccasionally runs in the background; I think it runs every now and then to change the app icon to current weather conditions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7656,7 +7926,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.iconpack.oneplus",
@@ -7665,7 +7935,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.iconpack.square",
@@ -7677,9 +7947,18 @@
     "removal": "Advanced"
   },
   {
+    "id": "cn.oneplus.oemtcma",
+    "list": "Oem",
+    "description": "TCMA = Tiered Contention Multiple Access\nRuns on boot.\nA form of CSMA/CA, a cellular traffic management protocol. TCMA schedules transmission of different types of traffic based on urgency.\nChina-only? (the \"cn\" in cn.oneplus is China's country code)\nhttps://en.wikipedia.org/wiki/Carrier-sense_multiple_access_with_collision_avoidance\nhttps://patents.google.com/patent/US20020163933A1",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
     "id": "cn.oneplus.oem_tcma",
     "list": "Oem",
-    "description": "TCMA stands for Tiered Contention Multiple Access, which is a cellular traffic management protocol.\nTCMA is a CSMA/CA protocol which schedules transmission of different types of traffic. \nI don't know if it's a good idea to remove given a CSMA/CA protocol improve QoS (https://en.wikipedia.org/wiki/Quality_of_service)\nAt the same time, it is most likely only used in China (ch.oneplus ==> China version) and for OnePlus apps.\nFYI : https://en.wikipedia.org/wiki/Carrier-sense_multiple_access_with_collision_avoidance\n",
+    "description": "TCMA = Tiered Contention Multiple Access\nRuns on boot.\nA form of CSMA/CA, a cellular traffic management protocol. TCMA schedules transmission of different types of traffic based on urgency.\nChina-only? (the \"cn\" in cn.oneplus is China's country code)\nhttps://en.wikipedia.org/wiki/Carrier-sense_multiple_access_with_collision_avoidance\nhttps://patents.google.com/patent/US20020163933A1",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7688,7 +7967,7 @@
   {
     "id": "com.oneplus.filemanager",
     "list": "Oem",
-    "description": "OnePlus file manager\n",
+    "description": "File manager\nStock OnePlus file manager app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7768,12 +8047,12 @@
   },
   {
     "id": "com.android.protips",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "Home screen tips\nRuns on boot.\nThe tip popups you get on the homescreen. Likely useless.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.mediatek.ygps",
@@ -7876,8 +8155,8 @@
   },
   {
     "id": "com.android.dialer",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "AOSP Dialer/Phone app\nDefault phone app on some older phones(like Oneplus 3).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7912,8 +8191,8 @@
   },
   {
     "id": "com.elephanttek.faceunlock",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Standard FaceUnlock functionality?\nUnlock your device by simply looking at the display.\nFace unlock is bad for security and privacy:\nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7948,17 +8227,17 @@
   },
   {
     "id": "android.autoinstalls.config.oneplus",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Device configuration\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "android.overlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nThe package name is pretty self-explanatory.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7967,7 +8246,7 @@
   {
     "id": "android.overlay.target",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nThe package name is pretty self-explanatory.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7976,7 +8255,7 @@
   {
     "id": "android.qvaoverlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nThe package name is pretty self-explanatory.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -7984,17 +8263,8 @@
   },
   {
     "id": "cn.oneplus.nvbackup",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "cn.oneplus.oemtcma",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "NVBackupUI\nRuns in the background on some phones.\nHandles things related to OTA system updates?\nSafe to disable, but might break OTA updates.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8002,12 +8272,12 @@
   },
   {
     "id": "cn.oneplus.opmms",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OPMmsLocation\nDetermines your location when sending SMS/MMS?\nChina-only? (\"cn\" is China's country code)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.android.bluetooth.overlay.common",
@@ -8021,7 +8291,7 @@
   {
     "id": "com.android.cellbroadcastreceiver.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme overlay for cellbroadcastreceiver?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8030,7 +8300,7 @@
   {
     "id": "com.android.cellbroadcastreceiver.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme overlay for cellbroadcastreceiver?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8038,8 +8308,8 @@
   },
   {
     "id": "com.android.cellbroadcastreceiver.overlay.common",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "com.android.cellbroadcastreceiver Theme pack\nGuessing it's a pack of themes for the cellbroadcastreceiver, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8048,7 +8318,7 @@
   {
     "id": "com.android.dialer.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme overlay for AOSP Dialer?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8057,7 +8327,7 @@
   {
     "id": "com.android.dialer.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme overlay for AOSP Dialer?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8066,7 +8336,7 @@
   {
     "id": "com.android.emergency.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme for Emergency rescue?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8075,7 +8345,7 @@
   {
     "id": "com.android.emergency.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme for Emergency rescue?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8083,8 +8353,8 @@
   },
   {
     "id": "com.android.mms.overlay.ct",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8111,7 +8381,7 @@
   {
     "id": "com.android.phone.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme for phone app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8120,7 +8390,7 @@
   {
     "id": "com.android.phone.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme for phone app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8129,7 +8399,7 @@
   {
     "id": "com.android.phone.overlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "Phone Services Theme pack\nGuessing it's a pack of themes for the stock phone app, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8138,7 +8408,7 @@
   {
     "id": "com.android.server.telecom.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme for something related to call network management?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8147,7 +8417,7 @@
   {
     "id": "com.android.server.telecom.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme for something related to call network management?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8156,7 +8426,7 @@
   {
     "id": "com.android.server.telecom.overlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "Call Management Theme pack\nGuessing it's a pack of themes for something related to call management, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8165,7 +8435,7 @@
   {
     "id": "com.android.settings.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme overlay for the Settings app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8174,7 +8444,7 @@
   {
     "id": "com.android.settings.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme overlay for the Settings app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8183,7 +8453,7 @@
   {
     "id": "com.android.settings.intelligence.basiccolorblack.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Dark theme overlay for the search functionality in the Settings app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8192,7 +8462,7 @@
   {
     "id": "com.android.settings.intelligence.basiccolorwhite.overlay",
     "list": "Pending",
-    "description": "",
+    "description": "Light theme overlay for the search functionality in the Settings app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8200,8 +8470,8 @@
   },
   {
     "id": "com.android.settings.overlay.ct",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8210,7 +8480,7 @@
   {
     "id": "com.android.systemui.overlay.common",
     "list": "Pending",
-    "description": "",
+    "description": "System UI Theme pack\nThe package name is pretty self-explanatory.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8263,26 +8533,35 @@
   },
   {
     "id": "com.oneplus",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Oneplus System\nHandles the Oneplus system framework? Possibly unsafe to disable, but please contribute information about what happens if you do.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.accessory",
+    "list": "Oem",
+    "description": "Oneplus Link\nI'm guessing this has to do with connecting to Oneplus accessories, like the Oneplus Buds (wireless earbuds). Might wanna keep it enabled if you use oneplus accessory devices.\nNoticed no negative effects from disable after weeks of use.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.account",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OnePlus Account\nEnables Oneplus account login on device.\nProbably handles authentication for Oneplus apps. Safe to remove if you don't use them.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.account.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme for Oneplus Account?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8290,8 +8569,17 @@
   },
   {
     "id": "com.oneplus.account.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme for Oneplus Account?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.android.cellbroadcast.overlay",
+    "list": "Oem",
+    "description": "Wireless emergency alerts Theme pack\nGuessing it's a pack of themes for the emergency alert UI, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8299,17 +8587,17 @@
   },
   {
     "id": "com.oneplus.aod",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Always On Display / Ambient Display\nRuns in the background.\nWhen enabled in settings it shows clock and notifications when you raise the phone or touch the screen.\nThis is basically a lower-power lock-screen. It could in theory reduce power draw if you check notifications/clock often as OLED screens draw minimal power showing a mostly black screen(black = pixel off), but in practice the number of times you'll unintentionally trigger it will likely eat up any potential power savings and more. And if your device doesn't have an OLED screen this will draw way more power.\nMost of these power savings could be applied to your standard lock-screen simply by making your background image completely black.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.aod.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for AOD? (Always On Display)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8317,8 +8605,8 @@
   },
   {
     "id": "com.oneplus.aod.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for AOD? (Always On Display)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8326,8 +8614,8 @@
   },
   {
     "id": "com.oneplus.aodnotification.overlay.gold",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "System UI Theme pack\nSeems to be a theme overlay for AOD (Always On Display).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8335,8 +8623,8 @@
   },
   {
     "id": "com.oneplus.aodnotification.overlay.purple",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "System UI Theme pack\nSeems to be a theme overlay for AOD (Always On Display).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8344,8 +8632,8 @@
   },
   {
     "id": "com.oneplus.aodnotification.overlay.red",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "System UI Theme pack\nSeems to be a theme overlay for AOD (Always On Display).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8353,8 +8641,8 @@
   },
   {
     "id": "com.oneplus.applocker",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Encrypts and locks apps behind password access.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8362,12 +8650,12 @@
   },
   {
     "id": "com.oneplus.appupgrader",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Built-in App Updates\nBased on the name I'm guessing it's an upater for built-in Oneplus apps?\nSeems safe to disable, but only seems to run on boot, so there's little to be gained from disabling.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.asti",
@@ -8380,26 +8668,26 @@
   },
   {
     "id": "com.oneplus.backuprestore.remoteservice",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Likely a backend service for OnePlus Switch(com.oneplus.backuprestore).\nProbably safe to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.calculator",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Stock Oneplus Calculator app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.calculator.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Calculator app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8407,8 +8695,8 @@
   },
   {
     "id": "com.oneplus.calendar.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for stock Calendar app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8416,8 +8704,8 @@
   },
   {
     "id": "com.oneplus.calendar.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for stock Calendar app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8425,8 +8713,8 @@
   },
   {
     "id": "com.oneplus.camera",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Camera\nThe stock Oneplus camera app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8434,17 +8722,17 @@
   },
   {
     "id": "com.oneplus.camera.service",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Runs in the background on some phones.\nNot sure what it does; camera functions fine without it. Could be related to photo backup?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.card.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Card package?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8452,8 +8740,8 @@
   },
   {
     "id": "com.oneplus.card.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Card package?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8479,12 +8767,12 @@
   },
   {
     "id": "com.oneplus.config",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OPConfig\nOccasionally runs in the background.\nPackage source is: OPOnlineConfig.apk\nGuessing it might handle communication certificates and general network config for Oneplus apps.\nOnly has INTERNET and RECEIVE_BOOT_COMPLETED permissions.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.contacts",
@@ -8497,8 +8785,8 @@
   },
   {
     "id": "com.oneplus.contacts.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Contacts?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8506,8 +8794,8 @@
   },
   {
     "id": "com.oneplus.contacts.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Contacts?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8515,8 +8803,17 @@
   },
   {
     "id": "com.oneplus.coreservice",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Android System\nImportant system package for Oneplus phones?\nRuns in the background as part of the system.\nContains broadcast dispatch and theme handler services.\nProbably unsafe to disable, but please contribute info about what happens if you do.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.dataoptimization",
+    "list": "Oem",
+    "description": "OPDataOptimization\nDoesn't contain any services and I've never seen it run.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8524,8 +8821,8 @@
   },
   {
     "id": "com.oneplus.deskclock",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Clock\nThe stock Oneplus clock app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8533,8 +8830,8 @@
   },
   {
     "id": "com.oneplus.deskclock.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Clock app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8542,8 +8839,8 @@
   },
   {
     "id": "com.oneplus.deskclock.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Clock app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8560,17 +8857,17 @@
   },
   {
     "id": "com.oneplus.dirac.simplemanager",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Runs in the background.\nMain Dirac service.\nAudio fidelity improvement from the Swedish company Dirac.\nAttempts to achieve a flat frequency response curve(i.e: fidelity). Should mainly improve speaker fidelity as it can be pre-calculated and stored as a corrective EQ curve, something not possible for most devices connected through the 3.5mm jack; presets only exist for a very limited number of headphones. Change for non-preset 3.5mm jack devices is just a generic EQ curve that could decrease fidelity just as likely as it could increase it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.dirac.simplemanager.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Dirac?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8578,8 +8875,8 @@
   },
   {
     "id": "com.oneplus.dirac.simplemanager.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Dirac?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8587,17 +8884,17 @@
   },
   {
     "id": "com.oneplus.faceunlock",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Face Unlock\nRuns in the background as part of the system.\nUnlock your device by simply looking at the display.\nFace unlock is bad for security and privacy:\nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.filemanager.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus File manager app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8605,8 +8902,8 @@
   },
   {
     "id": "com.oneplus.filemanager.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus File manager app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8614,17 +8911,17 @@
   },
   {
     "id": "com.oneplus.gallery",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Oneplus Gallery (https://play.google.com/store/apps/details?id=com.oneplus.gallery)\nOccasionally runs in the background. Some old versions of the app (like for Oneplus 3 on Android 9) don't run in the background.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.gamespace.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Game Space?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8632,8 +8929,8 @@
   },
   {
     "id": "com.oneplus.gamespace.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Game Space?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8641,26 +8938,35 @@
   },
   {
     "id": "com.oneplus.ifaaservice",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "IFAA = (China’s) Internet Finance Authentication Alliance\nProvides biometric authentication for Alipay. Safe to disable if you don't use it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.oneplus.minidumpoptimization",
+    "list": "Oem",
+    "description": "OPMinidumpOptimization\nRuns in the background.\nNot sure what it does, but haven't noticed any negative effects from weeks of having it disabled.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.mms",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OnePlus Messages (https://play.google.com/store/apps/details?id=com.oneplus.mms)\nOnly used on OnePlus 8 / 8 Pro according to the description.\nProbably safe to remove, just make sure to install another SMS app to not lose that functionality; QKSMS is a good FOSS replacement for basic SMS functionality and Google Messages is an option if you need full RCS support.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.mms.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme overlay for Oneplus Messages app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8668,8 +8974,8 @@
   },
   {
     "id": "com.oneplus.mms.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme overlay for Oneplus Messages app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8677,8 +8983,8 @@
   },
   {
     "id": "com.oneplus.note.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme overlay for Oneplus Notes app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8686,8 +8992,44 @@
   },
   {
     "id": "com.oneplus.note.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme overlay for Oneplus Notes app?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.odmoverlay.android",
+    "list": "Oem",
+    "description": "Android System Theme pack\nGuessing it's a pack of themes for some Oneplus-specific system components, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.odmoverlay.com.oneplus",
+    "list": "Oem",
+    "description": "Oneplus System Theme pack\nGuessing it's a pack of themes for Oneplus-specific system components, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.odmoverlay.com.android.settings",
+    "list": "Oem",
+    "description": "Settings Theme pack\nGuessing it's a pack of themes for the settings app, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.odmoverlay.com.android.systemui",
+    "list": "Oem",
+    "description": "System UI Theme pack\nGuessing it's a pack of themes for some Oneplus-specific system component, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8695,8 +9037,8 @@
   },
   {
     "id": "com.oneplus.opbackup",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "System Update\nRuns in the background.\nHandles things related to OTA system updates.\nSafe to disable, but probably breaks system updates.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8704,8 +9046,8 @@
   },
   {
     "id": "com.oneplus.opbackup.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for System Update?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8713,8 +9055,8 @@
   },
   {
     "id": "com.oneplus.opbackup.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for System Update?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8749,8 +9091,8 @@
   },
   {
     "id": "com.oneplus.screenrecord",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Screen Recorder\nThe Android 11 screen recorder with some Oneplus modifications.\nRuns the \"SystemUITileService\" when you have it as one of the quicksettings tiles, but doesn't seem to run in the background outside of that.\nDoesn't have an app icon, but you can create a shortcut to it with the Activity Launcher app.\nhttps://f-droid.org/en/packages/de.szalkowski.activitylauncher/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8758,8 +9100,8 @@
   },
   {
     "id": "com.oneplus.screenrecord.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Screenrecord?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8767,8 +9109,8 @@
   },
   {
     "id": "com.oneplus.screenrecord.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Screenrecord?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8794,17 +9136,17 @@
   },
   {
     "id": "com.oneplus.security",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dashboard\nRuns \"WidgetViewService\" and \"SecureService\" in the background.\nManages widget data access? Noticed no apparent ill effects on disable in Android 9.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.security.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme overlay for com.oneplus.security?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8812,8 +9154,8 @@
   },
   {
     "id": "com.oneplus.security.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme overlay for com.oneplus.security?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8821,35 +9163,35 @@
   },
   {
     "id": "com.oneplus.ses",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OPSes\nApk file name: OPSesAuthentication.\nContains a \"SesService\", but I've never seen it run.\nRelated to Amazon SES?(Simple Email Service) https://aws.amazon.com/ses/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.setupwizard",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "The Oneplus portion of the first-boot setup.\nRuns on boot, but not in the background beyond that.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.simcontacts",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "SimContacts Manager\nRuns in the background. Manages contacts and sync to SIM? Noticed no apparent ill effects on disable in Android 9.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.simcontacts.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme overlay for Oneplus SimContacts Manager app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8857,8 +9199,8 @@
   },
   {
     "id": "com.oneplus.simcontacts.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme overlay for Oneplus SimContacts Manager app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8867,7 +9209,7 @@
   {
     "id": "com.oneplus.sms.smscplugger",
     "list": "Pending",
-    "description": "",
+    "description": "Probably related to SMS based on the name?\nContains no services and I've never seen it run.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8875,17 +9217,26 @@
   },
   {
     "id": "com.oneplus.soundrecorder.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Overlay for Soundrecorder app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.soundrecorder.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Overlay for Soundrecorder app?",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.oneplus.telephonyoptimization",
+    "list": "Oem",
+    "description": "OPTelephonyOptimization\nContains a service with the same name, but I've never seen it run.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8893,35 +9244,35 @@
   },
   {
     "id": "com.oneplus.twspods",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "OnePlus Buds (https://play.google.com/store/apps/details?id=com.oneplus.twspods)\nCompanion app for Oneplus Buds. For updating firmware and changing settings.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.oneplus.wallpaper",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Pack of live wallpapers from Oneplus.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.wifiapsettings",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Wi-Fi Access Point Settings?\nRuns on boot.\nNoticed no change after disabling; Wi-Fi and related menus still seem fully functional.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.oneplus.wifiapsettings.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Dark theme for Wi-Fi Access Point Settings?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8929,8 +9280,8 @@
   },
   {
     "id": "com.oneplus.wifiapsettings.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Light theme for Wi-Fi Access Point Settings?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8939,7 +9290,7 @@
   {
     "id": "com.qualcomm.qti.devicestatisticsservice",
     "list": "Pending",
-    "description": "",
+    "description": "Runs in the background as part of the system.\nUnsure of importantance; could theoretically mess with efficiency if these stats are used by other system services/processes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8947,17 +9298,17 @@
   },
   {
     "id": "com.qti.diagservices",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "Starts process when plugged into a PC (with debugging on, haven't tried off) and then runs until stopped.\nCan't find info on what it is. Probably has to do with diagnostics for Android debugging?\nNoticed no ill effects from having it disabled for weeks.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.qti.ltebc",
-    "list": "Pending",
-    "description": "LTE Broadcast Manager",
+    "list": "Misc",
+    "description": "LTE Broadcast Manager\nRuns on boot, but not in the background beyond that.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -8974,8 +9325,8 @@
   },
   {
     "id": "com.qualcomm.qti.biometrics.fingerprint.service",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "Probably the background service for handling fingerprint authentication. Will likely break that if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9000,6 +9351,33 @@
     "removal": "Expert"
   },
   {
+    "id": "com.qualcomm.qtil.aptxals",
+    "list": "Misc",
+    "description": "Something to do with the AptX bluetooh audio streaming codec?\nRuns in the background as part of the system.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.qualcomm.qtil.aptxalsOverlay",
+    "list": "Misc",
+    "description": "com.qualcomm.qtil.aptxalsOverlay Theme pack\nGuessing it's a pack of themes for aptxalsOverlay, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.qualcomm.qtil.aptxui",
+    "list": "Misc",
+    "description": "Something to do with selecting codec for bluetooh audio streaming?\nRuns in the background as part of the system.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "com.recognize.number",
     "list": "Pending",
     "description": "",
@@ -9009,9 +9387,36 @@
     "removal": "Expert"
   },
   {
+    "id": "com.roaming.android.gsimbase",
+    "list": "Misc",
+    "description": "gsim = Global SIM? (SIM = Subscriber Identity Module, as in SIM-card)\nConsidering the \"roaming\" context that's my best guess.",
+    "dependencies": null,
+    "neededBy": "",
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.roaming.android.gsimcontentprovider",
+    "list": "Misc",
+    "description": "gsim = Global SIM? (SIM = Subscriber Identity Module, as in SIM-card)\nConsidering the \"roaming\" context that's my best guess.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.rongcard.eid",
+    "list": "Oem",
+    "description": "eid probably means Electronic ID. This presumably handles something related to that.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "net.oneplus.launcher",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Oneplus Launcher\nRuns in the background as part of the system.\nAside from obviously handling the default launcher itself, it also handles the Recents UI on Android 9, the home&recents gestures in Android 11, some submenus in the Settings app and possibly more that I'm unaware of.\nProbably not a good idea to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9019,8 +9424,8 @@
   },
   {
     "id": "net.oneplus.launcher.black.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for the Oneplus Launcher?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9028,8 +9433,8 @@
   },
   {
     "id": "net.oneplus.launcher.white.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for the Oneplus Launcher?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9037,8 +9442,8 @@
   },
   {
     "id": "net.oneplus.weather.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Weather app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9046,8 +9451,8 @@
   },
   {
     "id": "net.oneplus.weather.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Theme overlay for Oneplus Weather app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9081,6 +9486,24 @@
     "removal": "Expert"
   },
   {
+    "id": "com.android.wifi.resources.overlay.common",
+    "list": "Pending",
+    "description": "System Wi-Fi resources Theme pack\nGuessing it's a pack of themes for some Wi-Fi related system UI, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.wifi.resources.overlay.target",
+    "list": "Pending",
+    "description": "System Wi-Fi resources Theme pack\nGuessing it's a pack of themes for some Wi-Fi related system UI, based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "android.auto_generated_rro_product__",
     "list": "Pending",
     "description": "",
@@ -9100,24 +9523,6 @@
   },
   {
     "id": "com.android.hotspot2.osulogin",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "com.android.internal.display.cutout.emulation.hole",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "com.android.internal.display.cutout.emulation.waterfall",
     "list": "Pending",
     "description": "",
     "dependencies": null,
@@ -9172,17 +9577,17 @@
   },
   {
     "id": "com.google.android.as",
-    "list": "Pending",
-    "description": "",
+    "list": "Google",
+    "description": "Android System Intelligence (previously Device Personalization Services) (https://play.google.com/store/apps/details?id=com.google.android.as)\nRuns in the background.\n\"Enables intelligent features across Android\", like: Live Caption, Screen Attention, Improved Copy-Paste, App Predictions in the launcher, Notification Smart Actions, Smart Text Selection and Linkifying text in apps.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.google.android.cellbroadcastreceiver",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "Wireless emergency alerts\nCell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts.\nRuns at boot and is also triggered after exiting airplane mode.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know\nhttps://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver/+/refs/heads/master/src/com/android/cellbroadcastreceiver",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9190,6 +9595,15 @@
   },
   {
     "id": "com.google.android.cellbroadcastservice",
+    "list": "Pending",
+    "description": "Cell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.google.android.connectivity.resources",
     "list": "Pending",
     "description": "",
     "dependencies": null,
@@ -9200,7 +9614,7 @@
   {
     "id": "com.google.android.networkstack.tethering",
     "list": "Pending",
-    "description": "",
+    "description": "Used for USB and/or Wi-Fi tethering?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9218,7 +9632,16 @@
   {
     "id": "com.google.android.overlay.gmsconfig.common",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nGuessing it's a pack of overlay themes for Android System or Google Play Services based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.google.android.overlay.gmsconfig.comms",
+    "list": "Pending",
+    "description": "Android System Theme pack\nGuessing it's a pack of overlay themes for Android System or Google Play Services based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9227,7 +9650,7 @@
   {
     "id": "com.google.android.overlay.gmsconfig.gsa",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nGuessing it's a pack of overlay themes for Android System or Google Play Services based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9236,7 +9659,7 @@
   {
     "id": "com.google.android.overlay.gmsconfig.photos",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nGuessing it's a pack of overlay themes for Android System or Google Play Services based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9262,8 +9685,8 @@
   },
   {
     "id": "com.google.android.overlay.modules.documentsui",
-    "list": "Pending",
-    "description": "",
+    "list": "Aosp",
+    "description": "Files Theme pack\nGuessing it's a pack of themes for the stock Android File Browser, based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9272,7 +9695,7 @@
   {
     "id": "com.google.android.overlay.modules.modulemetadata.forframework",
     "list": "Pending",
-    "description": "",
+    "description": "Android System Theme pack\nGuessing it's a pack of themes for the Android System framework based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9281,7 +9704,7 @@
   {
     "id": "com.google.android.providers.media.module",
     "list": "Pending",
-    "description": "",
+    "description": "Media Storage\nIn Android 11 this is literally what provides access to files.\nSafe to disable, but NOT recommended; breaks file browsers and other forms of file access.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9290,7 +9713,7 @@
   {
     "id": "com.google.mainline.telemetry",
     "list": "Google",
-    "description": "It's a set of metrics-related modules. Google Play uses the version of the Telemetry module to determine\nif updates are available for metrics-related modules and which security patch version to display to the end user. \nThis module doesn’t contain active code and has no functionality on its own. \nRemoving modules-related packages may not be safe since Android 11\nhttps://gitlab.com/W1nst0n/universal-android-debloater/-/issues/27#note_410012436\n",
+    "description": "Contains data on which versions of modules are installed. Google Play uses this data to determine if updates are available for the modules, and to show which security patch is installed.\nThis module doesn’t contain active code and has no functionality on its own.\nhttps://www.xda-developers.com/android-project-mainline-modules-explanation/\nhttps://gitlab.com/W1nst0n/universal-android-debloater/-/issues/27#note_410012436",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9298,8 +9721,8 @@
   },
   {
     "id": "com.qti.qualcomm.deviceinfo",
-    "list": "Pending",
-    "description": "Device Info\nDisplays phone information\n(Settings -> About phone -> General information)",
+    "list": "Misc",
+    "description": "Device Info\nDisplays device information. Can be found in Settings->About phone.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9307,8 +9730,8 @@
   },
   {
     "id": "com.qualcomm.qti.cne",
-    "list": "Pending",
-    "description": "Related to Qualcomm connectivity engine (CnE)\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking",
+    "list": "Misc",
+    "description": "CneApp (Connectivity Engine)\nEnables seamless hand-off between mobile data and Wi-Fi networks. Can also dynamically measure network performance to prioritize using the best one (I think that's part of \"Intelligently select the best Wi-Fi\" in settings).\nProbably worth keeping on; I noticed connection reliability getting worse when I disabled it.\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking\nhttps://programmersought.com/article/35091829299/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9316,8 +9739,8 @@
   },
   {
     "id": "com.qualcomm.qti.ims",
-    "list": "Pending",
-    "description": "Related to IP Multimedia Services (IMS)\nhttps://www.qualcomm.com/news/releases/2015/03/02/qualcomm-powers-mobile-and-home-connectivity-innovations-mobile-world",
+    "list": "Misc",
+    "description": "IMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nGuessing this could be the low-level Qualcomm implementation or interface that allows apps to use the VoLTE/VoIP/Wi-Fi calling functionality in apps like the dialer/phone app.\nCould allow seamless transfers of calls between 4G and Wi-Fi? I thought com.qualcomm.qti.cne did that content-agnostically, but maybe calls are different, or maybe the two packages use each other?\nhttps://www.qualcomm.com/news/releases/2015/03/02/qualcomm-powers-mobile-and-home-connectivity-innovations-mobile-world",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9325,8 +9748,8 @@
   },
   {
     "id": "com.qualcomm.qti.performancemode",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "Performance Mode\nRuns on boot.\nProbably related to CPU/SoC performance profiles.\nOneplus 10 Pro has an option called \"High performance mode\" in Settings->Battery->Advanced, which has the description:\n\"The system always operates in a high performance mode, but it will increase power consumption.\"\nI'm guessing that option triggers this package. This is probably a feature on many Qualcomm chips, but I don't think all OEMs expose it in the settings.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9334,8 +9757,8 @@
   },
   {
     "id": "com.qualcomm.qti.poweroffalarm",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "Probably what enables alarms to start the device from an off state.\nRuns on boot and when you open a clock app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9343,8 +9766,8 @@
   },
   {
     "id": "com.qualcomm.qti.qdma",
-    "list": "Pending",
-    "description": "QDMA is Quadrature-division multiple access, a variant of communication from the same row with WiMax and CDMA.",
+    "list": "Misc",
+    "description": "QDMA = Quadrature-Division Multiple Access\nIt's a radio protocol combining CDMA and QPSK.\nQDMA is used for local area networks, usually wireless short-range such as WiMax.\nhttps://en.wikipedia.org/wiki/Quadrature-division_multiple_access",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9352,12 +9775,30 @@
   },
   {
     "id": "com.qualcomm.qti.gpudrivers.kona.api30",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "Adreno Graphics Drivers\nGPU drivers for Snapdragon 865 and 870.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.qualcomm.qti.gpudrivers.lahaina.api30",
+    "list": "Misc",
+    "description": "Adreno Graphics Drivers\nGPU drivers for Snapdragon 888.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.qualcomm.qti.gpudrivers.lito.api30",
+    "list": "Misc",
+    "description": "Adreno Graphics Drivers\nGPU drivers for Snapdragon 765G.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
   },
   {
     "id": "com.qualcomm.qti.qccauthmgr",
@@ -9370,8 +9811,8 @@
   },
   {
     "id": "com.qualcomm.qti.seccamservice",
-    "list": "Pending",
-    "description": "SecCamService, responsible for operation of the camera",
+    "list": "Misc",
+    "description": "SecCamService, stands for Secure Camera Service?\nSupposedly acts as a bridge between camera hardware and SoC. Seems like this package is what a Qualcomm SoC uses to access the camera hardware.\nWill probably break camera functionality if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9389,7 +9830,7 @@
   {
     "id": "com.qualcomm.qti.services.systemhelper",
     "list": "Pending",
-    "description": "Qualcomm System Helper Service.\nUncertain role...\n",
+    "description": "System Helper Service\nRuns \"SysHelperService\" in the background as part of the system.\nPermissions: DEVICE_POWER, READ_PHONE_STATE, READ_PRIVILEGED_PHONE_STATE, RECEIVE_BOOT_COMPLETED, WRITE_SETTINGS, WAKE_LOCK and ACCESS_SURFACE_FLINGER.\nUnclear what it does; need more info.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9414,33 +9855,24 @@
     "removal": "Expert"
   },
   {
-    "id": "com.qualcomm.qti.uceShimService",
-    "list": "Pending",
-    "description": "User Capability Echange service.\nUncertain role...\n",
+    "id": "com.qualcomm.qti.smq",
+    "list": "Misc",
+    "description": "QTR (Qualcomm Technology Reporting)\nRuns on boot.\nSeems like a telemetry package, supposedly sending hardware & software type, configuration and performance data.\nContains a \"QtiFeedbackActivity\" called \"Hardware Feedback\". When that hidden activity is launched through Activity Launcher you get a screen showing just a checkbox and this text:\n\"Collecting hardware and software type, configuration, and performance data helps Qualcomm improve next generation device battery life, security, and performance. Untick to disable.\"\nUnticking isn't remembered; it's ticked again next time you enter. There's also a \"Learn More\" link that leads to: http://reporting.qti.qualcomm.com/learnmore_en.html which doesn't load for me.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "com.qualcomm.qti.uimGbaApp",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.qualcomm.qti.workloadclassifier",
     "list": "Pending",
-    "description": "",
+    "description": "Runs \"WLCService\" in the background.\nI assume this has to do with CPU scheduling. Probably important for efficiency, if not basic operation.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
   },
-    {
+  {
     "id": "com.qualcomm.qti.xrvd.service",
     "list": "Pending",
     "description": "Possibly related to Qualcomm Extended Reality (XR)\nhttps://www.qualcomm.com/products/xr-vr-ar",
@@ -9450,27 +9882,9 @@
     "removal": "Expert"
   },
   {
-    "id": "com.qualcomm.uimremoteclient",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "com.qualcomm.uimremoteserver",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
     "id": "vendor.qti.hardware.cacert.server",
-    "list": "Pending",
-    "description": "",
+    "list": "Misc",
+    "description": "CACertApp\nOccasionally runs in the background.\nHandles CACert certificates? http://www.cacert.org/\nCACert is a community-driven CA that issues certificates to the public at large for free. CA = Certificate Authority, an entity that certifies the ownership of a public key that can be used for secure communications.\nProbably a bad idea to disable; could mess with device security.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9479,7 +9893,7 @@
   {
     "id": "vendor.qti.iwlan",
     "list": "Pending",
-    "description": "Used for VoLTE/VoWifi (Wifi-calling)\nIwLAN = Interworking wLAN. \nSupport for mobile data offloading (use of complementary network technologies for delivering data originally targeted \nfor cellular networks)\nConcretly, it most of the time it means your phone will switch to use the Wi-Fi connection instead of the cellular data connection. \nhttps://en.wikipedia.org/wiki/Mobile_data_offloading\n)\n",
+    "description": "Used for VoLTE/VoWifi (Wifi-calling)\nIwLAN = Interworking wLAN.\nSupport for mobile data offloading (use of complementary network technologies for delivering data originally targeted for cellular networks)\nIt means your phone will use the Wi-Fi connection instead of the cellular data connection.\nhttps://en.wikipedia.org/wiki/Mobile_data_offloading",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9956,7 +10370,7 @@
   {
     "id": "com.samsung.android.providers.contacts",
     "list": "Pending",
-    "description": "",
+    "description": "Likely same as com.android.providers.contacts, but for Samsung phones.\nProbably breaks contact functionality if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9965,7 +10379,7 @@
   {
     "id": "com.samsung.android.providers.media",
     "list": "Pending",
-    "description": "",
+    "description": "Likely same as com.android.providers.media; scans the device for media files and allows permitted apps access to them.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -10315,12 +10729,12 @@
   },
   {
     "id": "android.autoinstalls.config.TCL.PAI",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "AutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   {
     "id": "com.android.providers.tctdatahubprovider",
@@ -10441,8 +10855,8 @@
   },
   {
     "id": "com.tcl.faceunlock",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Standard FaceUnlock functionality?\nUnlock your device by simply looking at the display.\nFace unlock is bad for security and privacy:\nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -10738,8 +11152,8 @@
   },
   {
     "id": "com.tct.endusertest",
-    "list": "Pending",
-    "description": "Unused device issue feedback app",
+    "list": "Oem",
+    "description": "Unused device issue feedback app.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -10747,8 +11161,8 @@
   },
   {
     "id": "com.tct.faceunlock",
-    "list": "Pending",
-    "description": "",
+    "list": "Oem",
+    "description": "Standard FaceUnlock functionality?\nUnlock your device by simply looking at the display.\nFace unlock is bad for security and privacy:\nhttps://www.ubergizmo.com/2017/03/galaxy-s8-facial-unlock-photograph/\nhttps://www.kaspersky.com/blog/face-unlock-insecurity/21618/\nhttps://www.freecodecamp.org/news/why-you-should-never-unlock-your-phone-with-your-face-79c07772a28/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11036,7 +11450,7 @@
   {
     "id": "com.lge.drmservice",
     "list": "Oem",
-    "description": "LG Cloud\nBackup tool, which gives you the option to backup LG phone settings, apps, contacts and Home screen \nto your phone internal storage, SD card, computer or cloud.\nSource : https://www.apeaksoft.com/backup/lg-cloud-backup.html\n\nDRM Service\nNeeded to read DRM content playback. It manages the DRM Client, which holds a particular type of information required to get a license key. \nREMINDER : DRM = all the things that restrict the use of proprietary hardware and copyrighted works.\n==> https://en.wikipedia.org/wiki/Digital_rights_management\n==> https://creativecommons.org/2017/07/09/terrible-horrible-no-good-bad-drm/\n==> https://fckdrm.com/\n==> http://www.info-mech.com/drm_flaws.html\n",
+    "description": "DRM Service\nProbably required for some forms of DRM; disabling might break things like Netflix streaming, which relies on DRM to function.\nhttps://en.wikipedia.org/wiki/Digital_rights_management",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11117,7 +11531,7 @@
   {
     "id": "com.lge.gallery.vr.wallpaper",
     "list": "Oem",
-    "description": "LG 360 Image Wallpaper\nProvied VR (360°) wallpapers.\n",
+    "description": "LG 360 Image Wallpaper\nProvides VR (360°) wallpapers.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11288,11 +11702,11 @@
   {
     "id": "com.lge.lgdrm.permission",
     "list": "Oem",
-    "description": "Handle permissions for LG DRM (com.lge.drmservice).\nWhy does LG need a whole package for this ? \n",
+    "description": "Handle permissions for LG DRM (com.lge.drmservice).\nWhy does LG need a whole package for this?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.lge.lginstallservies",
@@ -11729,83 +12143,83 @@
   {
     "id": "com.android.providers.calendar.overlay.base.s600ww",
     "list": "Oem",
-    "description": "\"com.android.providers.calendar\" is necessary to sync stock Calendar app and lets it work correctly.\nI don't know what does this overlay add.\n#\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.settings.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Still otther overlays for android settings provider.\n\"com.android.providers.settings\" handles settings app datas (contentProvider)\n#\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.android.providers.settings.btl.s600ww.overlay",
     "list": "Oem",
-    "description": "Still otther overlays for android settings provider.\n\"com.android.providers.settings\" handles settings app datas (contentProvider)\n#\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Some overlay for a content provider package. Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.android.retaildemo.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for Retail demonstration mode\nhttps://en.wikipedia.org/wiki/Demo_mode\n",
+    "description": "Theme overlay for Retail demonstration mode?\nhttps://en.wikipedia.org/wiki/Demo_mode",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for ???\nNokia users don't see any differences when removed.\n",
+    "description": "Some kind of theme overlay for Nokia devices?\nSome users claim to not see any differences when removed.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.apnwidget.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Another overlay for APN widget this time. Seems useless to me\nREMINDER : APN means Access Point Name and must be configured with carrier values in order your device could acess carrier network. \n",
+    "description": "Some overlay for an APN widget. Overlays are usually themes.\nAPN means Access Point Name and must be configured with carrier values in order for your device to acess the carrier's network.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.AprUploadService.data.overlay.base.s600id",
     "list": "Oem",
-    "description": "Apr Upload Service ????\n",
+    "description": "Theme overlay for Apr Upload Service?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.autoregistration.overlay.d.base.s600ww",
     "list": "Oem",
-    "description": "Spyware app which sends warranty details to China\nhttps://milankragujevic.com/the-trade-of-privacy-for-convenience\nhttps://nitter.net/drwetter/status/1108801189662130176\n",
+    "description": "Theme overlay for a Spyware app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.d.base.s600e0",
     "list": "Oem",
-    "description": "Battery protect is advertised to improve battery performance but in practice it drains your battery and kills apps to aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/\n",
+    "description": "Theme overlay for Battery Protect?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.bboxsbox.app",
@@ -11819,43 +12233,43 @@
   {
     "id": "com.evenwell.bokeheditor.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Related to photos editing I think \n",
+    "description": "Theme overlay for Bokeh Editor?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600ww",
     "list": "Oem",
-    "description": "CP = Client Provisioning.\nSurely used to push new carrier internet/MMS settings automatically\nMaybe it's useful if carriers change their APN... but you still can change it manually, it's not difficult.\n",
+    "description": "Theme overlay for CPClient?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.customerfeedback.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Customer manager\nGiven its name it is useless but I don't have more info.\n",
+    "description": "Theme overlay for Customer Feedback?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Data agent\nUsed for backup/restore ? \n",
+    "description": "Theme overlay for Data Agent?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Debug config tool ? \n",
+    "description": "Theme overlay for Debug Config Tool?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11864,7 +12278,7 @@
   {
     "id": "com.evenwell.defaultappconfigure.overlay.base.s600ww",
     "list": "Oem",
-    "description": "????\n",
+    "description": "A theme overlay for selecting default apps or something?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11873,7 +12287,7 @@
   {
     "id": "com.evenwell.DeviceMonitorControl.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Monitor stuff obviously...\n",
+    "description": "Theme overlay for Device Monitor Control?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11882,7 +12296,7 @@
   {
     "id": "com.evenwell.email.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for email app\n",
+    "description": "Theme overlay for email app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11891,7 +12305,7 @@
   {
     "id": "com.evenwell.factorywizard.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Most likely a configuration setup after a factory reset (and/or after first boot)\nGuides you through the basics of setting up your device.\n",
+    "description": "Theme overlay for setup wizard?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11918,16 +12332,16 @@
   {
     "id": "com.evenwell.legalterm.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Provides terms and condition (legal notice)\n",
+    "description": "Theme overlay for some terms and conditions?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.managedprovisioning.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Seems to be a user interface related to settings description and wizard setup.\nhttps://en.wikipedia.org/wiki/Wizard_(software)\n",
+    "description": "Theme overlay for Managed Provisioning?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11945,7 +12359,7 @@
   {
     "id": "com.evenwell.nps.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Net Promoter Score\nPreinstalled survey.\n",
+    "description": "Theme overlay for Net Promoter Score?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11963,7 +12377,7 @@
   {
     "id": "com.evenwell.partnerbrowsercustomizations.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Customize your browser with stuff you don't want.\n",
+    "description": "Theme overlay for some browser customization?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11972,25 +12386,25 @@
   {
     "id": "com.evenwell.permissiondetection.overlay.base.s600ww",
     "list": "Oem",
-    "description": "????\n",
+    "description": "A theme overlay for something?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.phone.overlay.base",
     "list": "Oem",
-    "description": "Overlay for the dialer app\n",
+    "description": "Some overlay for the dialer app? Overlays are usually themes.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.PowerMonitor.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Drains more battery than it saves.\n",
+    "description": "Theme overlay for Power Monitor?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -11999,7 +12413,7 @@
   {
     "id": "com.evenwell.powersaving.g3.overlay.d.base.s600e0",
     "list": "Oem",
-    "description": "Is nokia powersaving really effective? \n",
+    "description": "Theme overlay for Power Saving?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12008,16 +12422,16 @@
   {
     "id": "com.evenwell.providers.downloads.ui.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Add most likey a useless overlay on the download app.\n",
+    "description": "Theme overlay for the downloads app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.providers.partnerbookmarks.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Provides Nokia bookmarks in Chrome/Nokia browser ?\n",
+    "description": "Theme overlay for Partner Bookmarks?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12026,25 +12440,25 @@
   {
     "id": "com.evenwell.providers.weather.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Provider for the Nokia weather app.\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Theme overlay for weather provider? Overlays are usually themes.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Surely related to push notifications for Nokia apps (only ?)\n",
+    "description": "Theme overlay for pushagent?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.retaildemoapp.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Nokia retail demonstration mode \nhttps://en.wikipedia.org/wiki/Demo_mode\n",
+    "description": "Theme overlay for Nokia retail demonstration mode?\nhttps://en.wikipedia.org/wiki/Demo_mode",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12053,34 +12467,34 @@
   {
     "id": "com.evenwell.screenlock.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for the screenlock\n",
+    "description": "Theme overlay for the lock-screen?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.settings.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay related to settings\n",
+    "description": "Theme overlay for settings?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.SettingsUtils.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Settings utils\n(crapy) Audio rendering. \nSee https://gitlab.com/W1nst0n/universal-android-debloater/-/issues/9#note_369056538\n",
+    "description": "Theme overlay for SettingsUtils?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.SetupWizard.overlay.base.s600ww",
     "list": "Oem",
-    "description": "It's the basic configuration wizard that drives you through first boot and guides you through the basics of setting up your device.\n",
+    "description": "Theme overlay for Setup Wizard?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12089,38 +12503,38 @@
   {
     "id": "com.evenwell.stbmonitor.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Apparently used to stabilize phone usage.\nSeems to mostly drain battery \n",
+    "description": "Theme overlay for STB Monitor?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.telecom.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Telecom telemetry?\n",
+    "description": "Theme overlay for something telecom-related?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.UsageStatsLogReceiver.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Logging stuff\n",
+    "description": "Theme overlay for Usage Stats Log?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.weatherservice.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for the weather app\n",
+    "description": "Theme overlay for weather service?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.fih.infodisplay",
@@ -12143,7 +12557,7 @@
   {
     "id": "com.foxconn.ifaa",
     "list": "Oem",
-    "description": "IFAA = China’s Internet Finance Authentication Alliance\nChinese organisation that aim to achieve a more simple way to verify the identity of human (like passwordless authentication)\n",
+    "description": "IFAA = (China’s) Internet Finance Authentication Alliance\nProvides biometric authentication for Alipay. Probably safe to disable if you don't use it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12152,7 +12566,7 @@
   {
     "id": "com.hmdglobal.datago.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Sends diagnostic data to HMD (Company behin Nokia) ?\n",
+    "description": "Theme overlay for this telemetry package?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12169,8 +12583,8 @@
   },
   {
     "id": "com.android.cellbroadcastreceiver.overlay.base.s600ww",
-    "list": "Oem",
-    "description": "Cell broadcast is a method of sending messages to multiple mobile telephone users in a defined area at the same time.\nIt is often used for regional emergency alerts. \nI think this package only handles notifications overlay for broadcast cell, not the implementation.\nIt seems to me that broadcast SMS use normal notifications so there is chances that this package provide special overlay for Nokia SMS app ?\n",
+    "list": "Pending",
+    "description": "Theme overlay for cellbroadcastreceiver?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12197,11 +12611,11 @@
   {
     "id": "com.evenwell.fmradio.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Nokia radio app \n",
+    "description": "Theme overlay for Nokia radio app?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.hdrservice",
@@ -12215,11 +12629,11 @@
   {
     "id": "com.evenwell.OTAUpdate.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Related to OTA Update (Over-The-Air updates, updates from Nokia)\nMay not be safe if you still receive updates.\n",
+    "description": "Theme overlay for OTA Update UI?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.coloros.appmanager",
@@ -12350,11 +12764,11 @@
   {
     "id": "com.coloros.soundrecorder",
     "list": "Oem",
-    "description": "ColorOS Sound Recorder\n",
+    "description": "ColorOS Sound Recorder",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.coloros.speechassist",
@@ -12440,7 +12854,7 @@
   {
     "id": "com.oppo.logkitservice",
     "list": "Oem",
-    "description": "",
+    "description": "Probably same as \"com.oem.oemlogkit\", which is a shady logging package on Oneplus devices.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12872,47 +13286,65 @@
   {
     "id": "org.codeaurora.ims",
     "list": "Misc",
-    "description": "IMS is an open industry standard for voice and multimedia communications over packet-based IP networks (Volte/VoIP/Wifi calling)\nThis his package is needed for the Volte/VoIP/Wifi calling provided by your carrier.\nThis is not needed by messaging apps (Signal, Telegram, WhatsApp...)\n",
+    "description": "IMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).\nRuns in the background as part of the system, with Google's IMS(com.google.android.ims, \"Carrier Services\") disabled, I haven't checked if it'd run with Carrier Services enabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
   },
   {
-    "id": "com.qti.qualcomm.datastatusnotification",
-    "list": "Misc",
-    "description": "Can read/send SMS\nAllows to cap data when you've reached the limit of your plan (not 100% sure)\n",
+    "id": "org.ifaa.aidl.manager",
+    "list": "Oem",
+    "description": "IfaaManagerService\nIFAA = (China’s) Internet Finance Authentication Alliance\nProvides biometric authentication for Alipay. Probably safe to disable if you don't use it.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
-    "id": "com.qti.service.colorservice",
+    "id": "com.qti.qualcomm.datastatusnotification",
     "list": "Misc",
-    "description": "Don't know why but it uses mobile data.\nIt most likely does something to colors on your display. Can someone see the difference ? Is it accessbility feature ?\nNeeded for Blue screen feature ?\n",
+    "description": "Sends you a message when you reach a specified data limit?\nContains a service, but I've never it run. But I've also never run out of data or used the Android data warning system.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qti.confuridialer",
     "list": "Misc",
-    "description": "Conference URI dialer. Also a conference call service, for digital signal only, as SIP / VoIP\nhttps://devcondition.com/article/removing-unneeded-miui-applications/\n",
+    "description": "Conference URI dialer\nConference call service for digital signal(SIP / VoIP).\nhttps://devcondition.com/article/removing-unneeded-miui-applications/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.qti.service.colorservice",
+    "list": "Misc",
+    "description": "Something to do with colors?\nContains a \"ColorServiceApp\" service, but I've never seen it run. Might be tied to some Display setting?\nProbably safe to disable; noticed no changes, but I also doubt there's any benefit to disabling it.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.qti.snapdragon.qdcm_ff",
     "list": "Misc",
-    "description": "Qualcomm Display Color Management tool\nWorks in background and \"enhance\" the display’s appearance through an intelligent color adjustment and gamut-mapping system \n\"to make colors look vibrant and true to life\".\nNot really convinced. Can someone see the difference ? \nhttps://www.qualcomm.com/news/onq/2016/05/02/qualcomm-trupalette-brings-your-phones-display-life\n#\nff = FinFet ? (https://en.wikipedia.org/wiki/FinFET)\n",
+    "description": "Qualcomm Display Color Management tool\nAttempts to \"make colors look vibrant and true to life\". No idea if it actually does something useful or if it's only some garbage dynamic color tuning (they tend to destroy colors).\nContains a service, but I've never seen it run on my Oneplus 9. Could be tied to color \"improvement\" settings in Settings->Display (all of which are off for me).\nhttps://www.qualcomm.com/news/onq/2016/05/02/qualcomm-trupalette-brings-your-phones-display-life",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.qualcomm.qti.qcolor",
+    "list": "Misc",
+    "description": "Something to do with colors?\nContains no services and I've never seen it run as a process. Only has one permission: CONTROL_DISPLAY_COLOR_TRANSFORMS\nProbably safe to disable; noticed no changes, but I also doubt there's any benefit to disabling it.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.atfwd",
@@ -12935,7 +13367,7 @@
   {
     "id": "com.qualcomm.embms",
     "list": "Misc",
-    "description": "Run in background.\nI guess it add support to LTE Broadcast or eMBMS (evolved Multimedia Broadcast Multicast Service) \nEnables carriers to sends stuff using multicast (same content to be delivered to a large number of users at the same time) instead of LTE.\nIt is a more efficient use of network resources when compared to each user receiving the same content individually.\nPersonally I don't want my carrier to send me stuff.\n#\nFYI : https://en.wikipedia.org/wiki/Multimedia_Broadcast_Multicast_Service\n\thttps://www.one2many.eu/en/lte-broadcast/what-is-embms\n",
+    "description": "Runs on boot, but not in the background beyond that?\nAdds support for eMBMS(evolved Multimedia Broadcast Multicast Service), also known as: LTE Broadcast\nEnables carriers to send content using multicast/broadcast (same content to many users at the same time) instead of unicast(to a single user).\nIt's a more efficient use of network resources compared to users receiving the same content individually.\nProbably safe to disable if you don't care about multi/broad-casts.\nhttps://en.wikipedia.org/wiki/Multimedia_Broadcast_Multicast_Service",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12944,16 +13376,16 @@
   {
     "id": "com.qualcomm.fastdormancy",
     "list": "Misc",
-    "description": "Provide Fast Dormancy feature/setting in the dialer (reduce battery consumption and network utilization during periods of data inactivity) \nhttps://en.wikipedia.org/wiki/Fast_Dormancy\n",
+    "description": "Provide Fast Dormancy feature/setting in the dialer (reduce battery consumption and network utilization during periods of data inactivity)\nhttps://en.wikipedia.org/wiki/Fast_Dormancy",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.location",
     "list": "Misc",
-    "description": "May enable your device to determine its location more quickly and accurately, even when your device is unable to get a strong GPS signal. \n**May** also help your device conserve battery power when you use applications or services requiring location data\nIt will periodically downloads data to your device regarding the locations of nearby cellular towers and WiFi access points\n#\nQualcomm Location periodically sends a unique software ID, the location of your device (longitude, latitude and altitude, and its uncertainty) \nand nearby cellular towers and Wi-Fi hotspots, signal strength, and time (collectively, “Location Data”) to Qualcomm servers. \nAs with any Internet communication, they also receive the IP address your device uses. \nhttps://www.qualcomm.com/site/privacy/services\n",
+    "description": "LocationServices\nRuns in the background as part of the system. Runs even if disabled, so probably pointless to disable.\nPeriodically sends a unique software ID, location (lat, long, alt, and their uncertainty), nearby cellular towers and Wi-Fi hotspots and their signal strength to Qualcomm servers.\nhttps://www.qualcomm.com/site/privacy/services",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12962,16 +13394,16 @@
   {
     "id": "com.qualcomm.qcrilmsgtunnel",
     "list": "Misc",
-    "description": "Tunnel between modem and android framework. Related to SMS? \nFYI : ril = Radio Interface layer. It's the bridge between Android phone framework services and the hardware.\nThere is no noticeable immediate consequences after disabling it but it'd better to know more about.\n",
+    "description": "Long-form name: Qualcomm Radio Interface Layer Message Tunnel.\nRuns in the background, both as part of user apps and as part of the system? It's an active system process even when disabled, but disabling seems to remove the user-side part of the process.\nDisabling yields no immediate consequences, but functionality may still be retained in the system process.\nActs as a bridge between Android framework services and the hardware? A tunnel between modem and Android framework?\nThe decompiled code shows nothing obvious. \"sendOemRilRequest\" seems like the only method name hinting at something.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.simcontacts",
     "list": "Misc",
-    "description": "Sim Contacts\nSafe to remove.\n \tI don't exactly know what's the purpose of this package. Import/Export tool?\n",
+    "description": "Sim Contacts\nProbably handles syncing(exporting/importing) contacts to/from the SIM card. Usually not a feature anybody cares about.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12989,7 +13421,16 @@
   {
     "id": "com.qualcomm.uimremoteserver",
     "list": "Misc",
-    "description": "UIM Remote Server\nUIM = User Identiy Module\nGiven its name I don't think it is a mandatory and pertinent feature. Can someone test?\n",
+    "description": "Contains a service by the same name, but I've never seen it run.\nRelated to SIM/R-UIM functionality? (R-UIM is a type of SIM card mainly used in Asia)",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.qualcomm.uimremoteclient",
+    "list": "Misc",
+    "description": "Contains a service by the same name, but I've never seen it run.\nRelated to SIM/R-UIM functionality? (R-UIM is a type of SIM card mainly used in Asia)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12998,11 +13439,11 @@
   {
     "id": "com.qualcomm.wfd.service",
     "list": "Misc",
-    "description": "Wifi Display\nProvides a way to cast your screen to your TV (support for Miracast)\nhttps://en.wikipedia.org/wiki/Miracast\n",
+    "description": "Wfd Service\nProvides a way to cast your screen to a TV (Miracast)\nhttps://en.wikipedia.org/wiki/Miracast",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.qualcomm.qti.auth.fidocryptoservice",
@@ -13016,7 +13457,7 @@
   {
     "id": "com.qualcomm.qti.autoregistration",
     "list": "Misc",
-    "description": "Collect device activation data to remotely activate a phone’s warranty\nFYI : In 2019 this package was sending private data (IMEI, CELLID , CCID) in CLEAR text to zzhc.vnet.cn (chinese server). \nAccording to HMD (Nokia) it was a mistake : \nhttps://www.androidauthority.com/nokia-7-plus-user-info-967901/\n",
+    "description": "Collects device activation data to remotely activate phone warranty.\nIn 2019 this package sent private data (IMEI, CELLID, CCID) in clear-text to zzhc.vnet.cn (chinese server). According to HMD (Nokia) it was a mistake:\nhttps://www.androidauthority.com/nokia-7-plus-user-info-967901/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13025,7 +13466,7 @@
   {
     "id": "com.qualcomm.qti.callenhancement",
     "list": "Misc",
-    "description": "Supposed to enhance call quality (I let you test if it really does)\nFYI : This app can record all your phone call\nA vulnerability was found in 2019, allowing unauthorized microphone audio recording by 3rd-party apps.\nhttps://nvd.nist.gov/vuln/detail/CVE-2019-15472\n",
+    "description": "Supposed to enhance call quality (I'll let you test if it really does)\nThis can record your phone calls. A vulnerability was found in 2019, allowing unauthorized microphone audio recording by 3rd-party apps.\nhttps://nvd.nist.gov/vuln/detail/CVE-2019-15472",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13034,25 +13475,25 @@
   {
     "id": "com.qualcomm.qti.callfeaturessetting",
     "list": "Misc",
-    "description": "Not mandatory (according to XDA users)\nCan someone explain what feature does this package add?\n",
+    "description": "Not mandatory according to some XDA users.\nMore info needed.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.confdialer",
     "list": "Misc",
-    "description": "ConfDialer\nLTE Conferencing Service\nHow to use this feature? It is nowhere explained.\n",
+    "description": "ConfDialer\nLTE Conferencing Service.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qti.dpmserviceapp",
     "list": "Misc",
-    "description": "Data Power Manager for the radio\nUsed to improve energy efficiency\n",
+    "description": "Data Power Manager for the radio.\nUsed to improve energy efficiency. Probably a bad idea to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13065,12 +13506,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.qualcomm.qti.optinoverlay",
     "list": "Misc",
-    "description": "Overlay for something but what... \n(nothing useful in any case)\n",
+    "description": "Overlay for opting into something? Probably safe to disable?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13079,7 +13520,7 @@
   {
     "id": "com.qualcomm.qti.qms.service.trustzoneaccess",
     "list": "Misc",
-    "description": "Handles access to the Qualcomm/ARM Trustzone?\nYou may not need Qualcomm Trustzone if you don't used OEM trusted apps.\nSee com.trustonic.tuiservice\n",
+    "description": "Handles access to Qualcomm/ARM Trustzone?\nMight not be needed if you don't use OEM trusted apps.\nSee com.trustonic.tuiservice",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13106,7 +13547,7 @@
   {
     "id": "com.qualcomm.qti.qms.service.telemetry",
     "list": "Misc",
-    "description": "Qualcomm Mobile Security, telemetry service.\nYeah obviously it phones to Qualcomm.\n",
+    "description": "Qualcomm Mobile Security\nTelemetry service. Obviously phones to Qualcomm.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13115,25 +13556,25 @@
   {
     "id": "com.qualcomm.qti.qtisystemservice",
     "list": "Misc",
-    "description": "Seems to only log stuff related to telephony\nA user removed this without noticing any issues\n",
+    "description": "Seems to only log stuff related to telephony?\nA user removed this without noticing any issues.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.roamingsettings",
     "list": "Misc",
-    "description": "Hidden settings menu\nLets to tweak roaming settings (How to access this settings?)\n",
+    "description": "Hidden settings menu for tweaking roaming settings? How exactly do you access this menu?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.qualcomm.qti.rcsimsbootstraputil",
     "list": "Misc",
-    "description": "RCS Service \nRCS = Rich Communication Services. \nRCS is a communication protocol between mobile telephone carriers and between phone and carrier, aiming at replacing SMS.\nhttps://en.wikipedia.org/wiki/Rich_Communication_Services\nNote that it uses IP protocol so you need to connect to Wifi/3G/4G...  to take advantage of it.\n#\nIt's a hot mess right now. It aims at being universal but you still need to have a Samsung Messages \nor Google Message. 3-party apps can't support it because google hasn't released a public API yet.\n\nIn a lot of country messages go through Google's Jibe servers.\nhttps://jibe.google.com/policies/terms/\n#\nhttps://pocketnow.com/why-you-should-probably-avoid-googles-rcs-text-messaging-chat-feature\n#\nDoes this packages is really needed for VolTE/VoWifi?\n",
+    "description": "RCS Service\nRCS = Rich Communication Services.\nRCS is a communication protocol between mobile telephone carriers and between phone and carrier, aiming at replacing SMS.\nhttps://en.wikipedia.org/wiki/Rich_Communication_Services\nUses IP protocol so it needs an internet connection.\nIt's a hot mess right now. It aims at being universal but only exists in Samsung Messages and Google Messages, because Google hasn't released a public API yet, so 3rd-party apps can't support it.\nIn a lot of countries messages go through Google's Jibe servers.\nhttps://jibe.google.com/policies/terms/\nhttps://pocketnow.com/why-you-should-probably-avoid-googles-rcs-text-messaging-chat-feature\nCan anybody check if this is needed for VolTE/VoWifi?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13142,16 +13583,25 @@
   {
     "id": "com.qualcomm.qti.uceshimservice",
     "list": "Misc",
-    "description": "UCE shim service \nUCE = User Capability Echange\nUsed for RCS. It provide a service  discovery  with  which  users  can  know  the capabilities of other users.\nUser capability exchange is based on SIP PUBLISH and then SIP SUBSCRIBE/NOTIFY. \nDevices would PUBLISH their capabilities to a presence server and then when another device wants to find out what \nthe other party is able to support, the device would send a SUBSCRIBE to the presence server and the presence server  \nwould then send a NOTIFY to the device of what the other party is able to support.\nSee https://fr.wikipedia.org/wiki/Session_Initiation_Protocol\nSee \"com.samsung.rcs\" in Samsung list for more information on RCS\n",
+    "description": "UCE shim service\nUCE = User Capability Exchange. A shim is basically a compatibility layer for an API, that makes sure anything that uses the API does so correctly.\nUsed for RCS. Provides a discovery service for users to see the capabilities of other users.\nUCE is based on SIP PUBLISH and SIP SUBSCRIBE/NOTIFY.\nDevices PUBLISH their capabilities to a presence server, when another device wants to find out what the other party supports, the device sends a SUBSCRIBE to the presence server which then returns a NOTIFY of what the other party supports.\nhttps://fr.wikipedia.org/wiki/Session_Initiation_Protocol",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.qualcomm.qti.uceShimService",
+    "list": "Misc",
+    "description": "UCE shim service\nUCE = User Capability Exchange. A shim is basically a compatibility layer for an API, that makes sure anything that uses the API does so correctly.\nUsed for RCS. Provides a discovery service for users to see the capabilities of other users.\nUCE is based on SIP PUBLISH and SIP SUBSCRIBE/NOTIFY.\nDevices PUBLISH their capabilities to a presence server, when another device wants to find out what the other party supports, the device sends a SUBSCRIBE to the presence server which then returns a NOTIFY of what the other party supports.\nhttps://fr.wikipedia.org/wiki/Session_Initiation_Protocol",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.timeservice",
     "list": "Misc",
-    "description": "Qualcomm Time Service\nIt maybe keeps the real time clock in the Qualcomm processor synchronised with Android time.\nSeems not safe to remove. \n",
+    "description": "Qualcomm Time Service\nOccasionally runs in the background.\nCould be what syncs the CPU clock with Android time?\nProbably not something you want to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13169,7 +13619,16 @@
   {
     "id": "com.quicinc.cne.CNEService",
     "list": "Misc",
-    "description": "Qualcomm Connectivity Engine\nAllow seamless calls between VoLTE and VoWiFi\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking\nhttps://programmersought.com/article/35091829299/\n",
+    "description": "Qualcomm Connectivity Engine\nEnables seamless hand-off between mobile data and Wi-Fi networks. Can also dynamically measure network performance to prioritize using the best one (I think that's part of \"Intelligently select the best Wi-Fi\" in settings).\nProbably worth keeping on; I noticed connection reliability getting worse when I disabled it.\nhttps://www.qualcomm.com/news/onq/2013/07/02/qualcomms-cne-bringing-smarts-3g4g-wi-fi-seamless-interworking\nhttps://programmersought.com/article/35091829299/",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.quicinc.voice.activation",
+    "list": "Misc",
+    "description": "Qualcomm Voice Assist\nAlways-on voice detection, so obviously always runs in the background.\nProbably worth keeping enabled for battery savings if you use Google Assistant regularly while your screen is off.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13178,43 +13637,34 @@
   {
     "id": "com.qualcomm.qti.dynamicddsservice",
     "list": "Misc",
-    "description": "Dynamic DDS Service\nDDS = Direct Digital Synthesizer\nTo make this very simple, it enables frequencies to be changed quickly without settling time.\nIt is very useful for testing, communications and frequency sweep applications. Not sure you need this in your phone.\nhttps://www.qualcomm.com/news/releases/1996/05/07/qualcomm-introduces-new-high-speed-dual-direct-digital-synthesizer\nIf you want to know more about the use of a DDS : https://www.allaboutcircuits.com/technical-articles/direct-digital-synthesis/\n",
+    "description": "Dynamic DDS Service\nDDS = Direct Digital Synthesizer. Supposedly useful for testing, communication and frequency sweep applications. Some apps may use this for local communication between devices? I'm guessing this is related to sending data through audio(a bunch of rapid beeps outside of the range of human hearing), which I believe Google Home used(still uses?) at one point as an option to connect to a Chromecast.\nhttps://www.qualcomm.com/news/releases/1996/05/07/qualcomm-introduces-new-high-speed-dual-direct-digital-synthesizer\nInfo about DDS: https://www.allaboutcircuits.com/technical-articles/direct-digital-synthesis/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
-  },
-  {
-    "id": "com.qualcomm.qti.gpudrivers.lito.api30",
-    "list": "Misc",
-    "description": "Adreno Graphics Drivers",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Unsafe"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.lpa",
     "list": "Misc",
-    "description": "Only useful if you use an esim (virtual sim)\nlpa = Local Profile Assistants. It is a software that allows consumers to choose and change their subscription data when switching between \nnetwork operators/carriers.\nhttps://developer.qualcomm.com/blog/rise-esims-and-isims-and-their-impact-iot\nhttps://source.android.com/devices/tech/connect/esim-overview\n",
+    "description": "lpa = Local Profile Assistants\nRuns on boot, but not in the background beyond that.\nCode has a lot of references to UIM(User Identity Module, which is SIM-related)\nOnly useful if you use an eSIM? (electronic SIM)\nAllows users to choose and change their subscription data when switching between network operators/carriers.\nhttps://developer.qualcomm.com/blog/rise-esims-and-isims-and-their-impact-iot\nhttps://source.android.com/devices/tech/connect/esim-overview",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.remoteSimlockAuth",
     "list": "Misc",
-    "description": "Enable you to lock/unlock your eSIM remotely.\nSeems more of a security risk to me than anything else.\nIs it related to Safeswitch ? https://www.qualcomm.com/products/features/security/safeswitch\n",
+    "description": "Authentication for locking/unlocking eSIM remotely?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.qualcomm.qti.simsettings",
     "list": "Misc",
-    "description": "Obviously related to SIM settings\n",
+    "description": "Related to SIM settings? Exact nature is unclear.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13223,7 +13673,7 @@
   {
     "id": "com.qualcomm.qti.telephonyservice",
     "list": "Misc",
-    "description": "Sound processing during phonecalls\nYou absolutely need this package.\n",
+    "description": "Sound processing during phonecalls.\nRuns in the background.\nVital package for making calls.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13241,20 +13691,29 @@
   {
     "id": "com.qualcomm.qti.uim",
     "list": "Misc",
-    "description": "Related to RUIM I guess. It is a kind of SIM card\nhttps://en.wikipedia.org/wiki/Removable_User_Identity_Module\nStill used in China it seems.\n",
+    "description": "Runs \"RemoteSimLockService\" in the background.\nThis might be the only remote SIM lock service, just called UIM because R-UIM(Removeable-UserIdentityModule) is a variant of SIM commonly used in Asia.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
   },
   {
-    "id": "com.quicinc.fmradio",
+    "id": "com.qualcomm.qti.uimGbaApp",
     "list": "Misc",
-    "description": "quicinc = Qualcomm Innovation Center\nFM Radio app by Qualcomm\n",
+    "description": "Contains a \"GbaService\", but I've never seen it run.\nRelated to SIM/R-UIM functionality? (R-UIM is a type of SIM card mainly used in Asia)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.quicinc.fmradio",
+    "list": "Misc",
+    "description": "FM Radio app by Qualcomm\nquicinc = Qualcomm Innovation Center",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
   },
   {
     "id": "com.qualcomm.qti.qmmi",
@@ -13277,7 +13736,7 @@
   {
     "id": "com.android.ld.appstore",
     "list": "Misc",
-    "description": "AAA Mobile (https://play.google.com/store/apps/details?id=com.aaa.android.discounts)\nKind of GPS that helps you find Point of interest (POI) like hotels, restaurants, and car repair facilities from the AAA databases.\nNOTE : You’ll have to sign up for an AAA membership to enjoy all of the features and functionality of the Android app.\nAAA = American Automobile Association\n\nLD Gaming Appstore\nLDPlayer is an Android Gaming emulator pour PC (https://ldplayer.net/)\n",
+    "description": "LD Gaming Appstore\nLDPlayer is an Android Gaming emulator for PC (https://ldplayer.net/)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13664,7 +14123,7 @@
   {
     "id": "com.netflix.partner.activation",
     "list": "Misc",
-    "description": "Netflix activation via partner manufacturer ? \n",
+    "description": "Apk file name: By_3rd_NetflixActivationOverSeas\nSome form of activation of Netflix account, subscription or app? Might be what puts the Netflix app icon on the homescreen. Not sure.\nNetflix app works without this.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -13854,15 +14313,6 @@
     "id": "com.rhapsody",
     "list": "Misc",
     "description": "Napster Music (https://play.google.com/store/apps/details?id=com.rhapsody)\nNapster streaming app\nhttps://en.wikipedia.org/wiki/Napster\n",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
-    "id": "com.roaming.android.gsimcontentprovider",
-    "list": "Misc",
-    "description": "GSIM = Generic Statistical Information Model ? I don't think so but I can't find anything.\n",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14194,12 +14644,12 @@
   },
   {
     "id": "se.dirac.acs",
-    "list": "Misc",
-    "description": "Earphone audio quality improvement from the Swedish company Dirac.\nThe technology relies on impulse and magnitude frequency response correction to deliver a more dynamic soundstage, \neven when connected to budget headphones. \nThe goal is to improve overall sound clarity and bass fidelity while correcting the frequency response so as to deliver a flat curve.\nCan be disabled in Settings/Additional settings/Headphone and audio effects (to try to hear the difference)\nhttps://www.androidcentral.com/heres-how-dirac-enabling-xiaomi-create-better-audio-products\n",
+    "list": "Oem",
+    "description": "Dirac Control Service\nSound-system backend?\nRuns in the background as part of the system. Runs even if disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "tv.fubo.mobile.vpl",
@@ -14249,20 +14699,20 @@
   {
     "id": "com.dsi.ant.server",
     "list": "Misc",
-    "description": "ANT HAL(Hardware Abstraction Layer) Server\n",
+    "description": "ANT HAL(Hardware Abstraction Layer) Server\nANT is a wireless protocol, similar to Bluetooth, that is mainly used for sport and fitness trackers.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.dsi.ant.service.socket",
     "list": "Misc",
-    "description": "ANT Radio Service (https://play.google.com/store/apps/details?id=com.dsi.ant.service.socket)\nit is NOT related to Radio FM !\n",
+    "description": "ANT Radio Service (https://play.google.com/store/apps/details?id=com.dsi.ant.service.socket)\nANT is a wireless protocol, similar to Bluetooth, that is mainly used for sport and fitness trackers.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "co.sitic.pp",
@@ -14276,7 +14726,7 @@
   {
     "id": "com.gd.mobicore.pa",
     "list": "Misc",
-    "description": "Mobicore is now Trustonic\nTrustonic is a small OS running on the CPU providing a TEE, an isolated environment that runs in parallel \nwith the operating system, guaranteeing code and data loaded inside to be protected.\nThat's sound great but it's closed source and \"normal\" devs can't use it for their apps.\nSee \"com.trustonic.tuiservice\"\n",
+    "description": "Mobicore is now Trustonic\nTrustonic is a small OS running on the CPU providing a TEE, an isolated environment that runs in parallel with the operating system, guaranteeing code and data loaded inside to be protected.\nSounds great, but it's closed source and \"normal\" devs can't use it for their apps.\nSee \"com.trustonic.tuiservice\"",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14294,7 +14744,7 @@
   {
     "id": "com.trustonic.tuiservice",
     "list": "Misc",
-    "description": "The tuiService (Trusted User Interface) is a new security layer implemented by Trustonic.\nAllows a Trusted Application to interact directly with the user via a common display and touch screen, completely isolated from the main device OS.\nSeems like a good idea but it's closed source and \"normal\" devs can't use it for their apps. \nhttps://stackoverflow.com/questions/16909576/how-to-make-use-of-arm-trust-zone-in-android-application\nIt is basically only used by manufacturer apps like Samsung Pay and for DRM stuff.\nGoogle implemented their own TUI in Android Pie : https://android-developers.googleblog.com/search/label/Trusted%20User%20Interface\n\nhttps://www.trustonic.com/news/blog/benefits-trusted-user-interface/\nhttps://en.wikipedia.org/wiki/Trusted_execution_environment\n#\nIf you're wondering, deleting theses packages will not cause security issues. It will break Trustonic TEE for sure\nbut if you don't use Trusted Apps. You won't need this ! \nDeleting this **may** reduce attack surface if your phone still has Trusted apps... because yeah, Trustonic TEE isn't foolproof (as it was claimed)\nhttps://en.wikipedia.org/wiki/ARM_architecture#Security_extensions\nhttps://googleprojectzero.blogspot.com/2017/07/trust-issues-exploiting-trustzone-tees.html\nhttps://www.synacktiv.com/posts/exploit/kinibi-tee-trusted-application-exploitation.html\nhttps://blog.quarkslab.com/introduction-to-trusted-execution-environment-arms-trustzone.html\n#\nGood ressources : \nhttps://medium.com/@nimronagy/arm-trustzone-on-android-975bfe7497d2\nhttps://www.gsd.inesc-id.pt/~nsantos/papers/pinto_acsur19.pdf\nhttps://blog.quarkslab.com/introduction-to-trusted-execution-environment-arms-trustzone.html\nhttps://medium.com/taszksec/unbox-your-phone-part-i-331bbf44c30c\n#\nNOTE : Trustonic TEE (called Kinibi) is used in Samsung, Vivo, Oppo, Xiaomi, Meizu and LG devices.\n",
+    "description": "tuiService (Trusted User Interface) is a security layer by Trustonic.\nAllows a \"Trusted App\" to interact directly with the user, completely isolated from the device OS.\nIt's closed source and normal devs can't use it for their apps.\nhttps://stackoverflow.com/questions/16909576/how-to-make-use-of-arm-trust-zone-in-android-application\nMainly used by OEM apps like Samsung Pay and for DRM.\nGoogle implemented their own TUI in Android Pie: https://android-developers.googleblog.com/search/label/Trusted%20User%20Interface\nhttps://www.trustonic.com/news/blog/benefits-trusted-user-interface/\nhttps://en.wikipedia.org/wiki/Trusted_execution_environment\nDisabling will break \"Trusted Apps\".\nhttps://en.wikipedia.org/wiki/ARM_architecture#Security_extensions\nhttps://googleprojectzero.blogspot.com/2017/07/trust-issues-exploiting-trustzone-tees.html\nhttps://www.synacktiv.com/posts/exploit/kinibi-tee-trusted-application-exploitation.html\nhttps://blog.quarkslab.com/introduction-to-trusted-execution-environment-arms-trustzone.html\nGood ressources:\nhttps://medium.com/@nimronagy/arm-trustzone-on-android-975bfe7497d2\nhttps://www.gsd.inesc-id.pt/~nsantos/papers/pinto_acsur19.pdf\nhttps://blog.quarkslab.com/introduction-to-trusted-execution-environment-arms-trustzone.html\nhttps://medium.com/taszksec/unbox-your-phone-part-i-331bbf44c30c",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14375,7 +14825,7 @@
   {
     "id": "com.mediatek.ims",
     "list": "Misc",
-    "description": "Mediatek's implementation of IMS\nhttps://www.programmersought.com/article/50164530665/\nNote: IMS is an open industry standard for voice and multimedia communications over packet-based IP networks (Volte/VoIP/Wifi calling).\nUnless you use VolTE (wifi calling) or RCS from Google or your carrier you don't need IMS.\nI'm also not sure to understand the purpose of this package because there already is \"com.google.android.ims\" on the phone.\nCan someone remove this package and test if IMS still works?\n",
+    "description": "Mediatek's implementation of IMS (low-level implementation?)\nhttps://www.programmersought.com/article/50164530665/\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14402,7 +14852,7 @@
   {
     "id": "com.mediatek.nlpservice",
     "list": "Misc",
-    "description": "Mediatek Network Location Provider\nProvides periodic reports on the geographical location of the device. Each provider has a set of criteria under which it may be used.\nFor example, some providers require GPS hardware and visibility to a number of satellites others require the use of \nthe cellular radio, or access to a specific carrier's network, or to the internet. \nThey may also have different battery consumption characteristics or monetary costs to the user.\n\nI don't really understand why you would need this as there is already one in 'com.google.android.gms'\nI wonder if NLP can be replaced by https://github.com/microg/UnifiedNlp\nI suggest to test if you get a better signal/battery performance with Mediatek NLP, if not you can get rid of it.\n",
+    "description": "Mediatek Network Location Provider\nProvides periodic reports on the geographical location of the device. Each provider has a set of criteria under which it may be used. For example, some providers require GPS hardware and visibility to a number of satellites, while others require the use of the cellular radio, or access to a specific carrier's network, or to the internet.\nI don't understand why this is needed; there already is one in 'com.google.android.gms'\nI wonder if NLP can be replaced by https://github.com/microg/UnifiedNlp\nI suggest testing if you get a better signal/battery performance with Mediatek NLP on or off.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14411,7 +14861,7 @@
   {
     "id": "com.mediatek.omacp",
     "list": "Misc",
-    "description": "omacp = OMA Client Provisioning. It is a protocol specified by the Open Mobile Alliance (OMA).\nConfiguration messages parser. Used for provisioning APN settings to devices via SMS \nIn my case, it was automatic and I never needed configuration messages.\nMaybe it's useful if carriers change their APN. But you still can change the config manually, it's not difficult.\nDunno why Mediatek handles this kind of things. Safe to remove. At worst, you'll need to manually config your APN.\nNote: OMACP can be abused. Be careful:\nhttps://research.checkpoint.com/2019/advanced-sms-phishing-attacks-against-modern-android-based-smartphones/\nhttps://www.zdnet.com/article/samsung-huawei-lg-and-sony-phones-vulnerable-to-rogue-provisioning-messages/\n",
+    "description": "omacp = OMA Client Provisioning. A protocol specified by the Open Mobile Alliance (OMA).\nConfiguration messages parser. Used for provisioning APN settings to devices via SMS.\nIn my case, it was automatic and I never needed configuration messages.\nMaybe it's useful if carriers change their APN. But you can still change the config manually, it's not difficult.\nDunno why Mediatek handles this kind of things. Safe to remove. At worst, you'll need to manually config your APN.\nOMACP can be abused:\nhttps://research.checkpoint.com/2019/advanced-sms-phishing-attacks-against-modern-android-based-smartphones/\nhttps://www.zdnet.com/article/samsung-huawei-lg-and-sony-phones-vulnerable-to-rogue-provisioning-messages/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14420,16 +14870,16 @@
   {
     "id": "com.mediatek.providers.drm",
     "list": "Misc",
-    "description": "DRM provider (actually Beep Science is the MediaTek’s default DRM vendor)\nYou probably need this if you want to watch Netflix & others stuff in high-res \nREMINDER : DRM = all the things that restrict the use of proprietary hardware and copyrighted works.\n==> https://en.wikipedia.org/wiki/Digital_rights_management\n==> https://creativecommons.org/2017/07/09/terrible-horrible-no-good-bad-drm/\n==> https://fckdrm.com/\n==> http://www.info-mech.com/drm_flaws.html\n",
+    "description": "DRM provider (actually Beep Science is MediaTek’s default DRM vendor)\nProbably required for some forms of DRM; disabling might break things like Netflix streaming, which relies on DRM to function.\nhttps://en.wikipedia.org/wiki/Digital_rights_management",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.mediatek.wfo.impl",
     "list": "Misc",
-    "description": "According to olorin (https://www.olorin.me/2019/09/08/debloating-the-umidigi-f1-play/)\nit's the MediaTek’s default fingerprint app (and he removed it)\nCan someone confirm what does this package exactly do? \nRemember that any preinstalled apps you don't actually need just increase the surface attack.\nVulnerability found in 2019: https://nvd.nist.gov/vuln/detail/CVE-2019-15368\nAny app co-located on the device could modify a system property through an exported interface without proper authorization.\n)\n",
+    "description": "According to olorin (https://www.olorin.me/2019/09/08/debloating-the-umidigi-f1-play/) it's MediaTek’s default fingerprint app (and he removed it).\nCan someone confirm what this package does?\nRemember that any preinstalled apps you don't actually need just increase the surface attack.\nVulnerability found in 2019: https://nvd.nist.gov/vuln/detail/CVE-2019-15368\nAny app co-located on the device could modify a system property through an exported interface without proper authorization.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14438,9 +14888,36 @@
   {
     "id": "android.autoinstalls.config.Xiaomi.cactus",
     "list": "Oem",
-    "description": "android.autoinstalls.config.Xiaomi.X where X is the phone's codename\nUsed to **auto** install stuff\nIMO it's a similar feature than Play Auto Install (https://forum.xda-developers.com/xperia-z/help/how-stop-google-play-auto-install-t2590253)\n",
+    "description": "Cactus is the device codename.\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
     "dependencies": null,
     "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "android.autoinstalls.config.Xiaomi.cepheus",
+    "list": "Oem",
+    "description": "Cepheus is the device codename.\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
+    "dependencies": null,
+    "neededBy": "",
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "android.autoinstalls.config.Xiaomi.daisy",
+    "list": "Oem",
+    "description": "Daisy is the device codename.\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
+    "dependencies": null,
+    "neededBy": "",
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "android.autoinstalls.config.Xiaomi.dipper",
+    "list": "Oem",
+    "description": "Dipper is the device codename.\nAutoInstalls a set of OEM apps on device setup (first boot/factory reset).",
+    "dependencies": null,
+    "neededBy": "",
     "labels": null,
     "removal": "Recommended"
   },
@@ -14717,7 +15194,7 @@
   {
     "id": "com.miui.micloudsync",
     "list": "Oem",
-    "description": "Mi Cloud Sync\nNeeded for Cloud syncronisation\n",
+    "description": "Mi Cloud Sync\nNeeded for Cloud synchronization.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -14987,7 +15464,7 @@
   {
     "id": "com.miui.providers.weather",
     "list": "Oem",
-    "description": "Xiaomi provider for MI Weather app (com.miui.weather)\nREMINDER : Content providers helps an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource: https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Provider for MI Weather app (com.miui.weather)\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15248,7 +15725,7 @@
   {
     "id": "com.qiyi.video",
     "list": "Oem",
-    "description": "IQIYI (https://play.google.com/store/apps/details?id=com.qiyi.video_US)\nOnline video platform from Baidu (https://en.wikipedia.org/wiki/IQiyi).\nI didn't know this is currently one of the largest online video sites in the world, \nwith nearly 6 billion hours spent on its service each month, and over 500 million monthly active users.\n",
+    "description": "IQIYI (https://play.google.com/store/apps/details?id=com.qiyi.video)\nOnline video platform from Baidu (https://en.wikipedia.org/wiki/IQiyi).\nI didn't know this is currently one of the largest online video sites in the world, \nwith nearly 6 billion hours spent on its service each month, and over 500 million monthly active users.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15455,7 +15932,7 @@
   {
     "id": "com.xiaomi.providers.appindex",
     "list": "Oem",
-    "description": "Provider for indexing app ? \nI believe it is a provider for the settings but I can't confirm (I don't have a Xiaomi device)\nA lot of people debloat this but I'd like to know more about this one.\n",
+    "description": "Provider for app index?\nI believe it is a provider for the settings but can't confirm (I don't have a Xiaomi device).\nA lot of people debloat this but I'd like to know more about this one.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15500,7 +15977,7 @@
   {
     "id": "com.android.systemui.overlay.ct",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15509,7 +15986,7 @@
   {
     "id": "com.android.systemui.overlay.ct",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15518,7 +15995,7 @@
   {
     "id": "android.telephony.overlay.cmcc",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15527,7 +16004,7 @@
   {
     "id": "com.android.mms.overlay.cmcc",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15536,7 +16013,7 @@
   {
     "id": "com.android.settings.overlay.cmcc",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15545,7 +16022,7 @@
   {
     "id": "com.android.systemui.overlay.cmcc",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15554,7 +16031,7 @@
   {
     "id": "com.android.networksettings.overlay.ct",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15563,7 +16040,7 @@
   {
     "id": "com.android.systemui.overlay.ct",
     "list": "Oem",
-    "description": "Very likely to be a bunch of overlay theme from the China Mobile Communications Corporation (CMCC) / China Telecom (CT)\nCan someone remove them and see what exactly happens?\n",
+    "description": "Likely overlay themes from China Mobile Communications Corporation(CMCC) or China Telecom(CT).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15572,7 +16049,7 @@
   {
     "id": "com.miui.wmsvc",
     "list": "Oem",
-    "description": "WMService\nRun at boot, has access to internet + GPS\nI quickly looked at the decompiled code and I saw some unsanitized SQL inputs which is BAD! (vulnerable to SQL injection)\nTry to get your android unique Google advertising ID from Google Play Services.\nFeed and launch the spying/analytics app \"com.miui.hybrid\"\nThis app doesn't seems to do essential things except for tracking.\nWARNING: Some people said removing this app causes bootloop, others said it's not. \nI'd like someone to check this. I think it should be okay if you remove all other linked Xiaomi crapwares (like the script does)\n",
+    "description": "WMService\nRuns at boot, has access to internet + GPS\nI quickly looked at the decompiled code and saw some unsanitized SQL inputs, which is BAD! (vulnerable to SQL injection)\nTries to get your android unique Google advertising ID from Google Play Services.\nFeeds and launches the spying/analytics app \"com.miui.hybrid\".\nDoesn't seem to do anything important, only tracking.\nWARNING: Some people said removing this package causes bootloop, others said it doesn't. Can someone check this? I think it should be okay to remove if you remove all other dependent Xiaomi packages(bloat).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15599,7 +16076,7 @@
   {
     "id": "com.xiaomi.location.fused",
     "list": "Oem",
-    "description": "FusedLocationProvider\nIt uses a combination of a device’s GPS, Wi-Fi and internal sensors to improve geolocation performance.\nThe thing is there is also a Fused Location Provider embeded in 'com.google.android.gms'\nThis Xiaomi location provider obviously has as much tracking as the Google one but if you can remove one tracking source\nit's still better than nothing.\nCan someone try to remove this package and give feedback please?\n",
+    "description": "FusedLocationProvider\nIt uses a combination of GPS, Wi-Fi and internal sensors to improve geolocation performance.\nThere's also a Fused Location Provider embeded in 'com.google.android.gms'\nThis Xiaomi location provider obviously has as much tracking as the Google one but if you can remove one tracking source it's better than nothing.\nCan someone try disabling this package and give feedback?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15662,7 +16139,7 @@
   {
     "id": "com.fido.xiaomi.uafclient",
     "list": "Oem",
-    "description": "FIDO UAF Autenthicator-Specific Module.\nSee 'com.huawei.fido.uafclient' for FIDO explaination.\nThe UAF Authenticator-Specific Module (ASM) is a software interface on top of UAF authenticators which gives a standardized way for FIDO UAF clients \nto detect and access the functionality of UAF authenticators and hides internal communication complexity from FIDO UAF Client.\nSource: https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-asm-api-v1.0-ps-20141208.html\n\nUAF client for FIDO.\nFido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\n#\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device \nto the online service and using a local authentication mechanism such as iris or fingerprint recognition. .\nhttps://developers.google.com/identity/fido/android/native-apps\nSafe to remove if you don't use password-less authentification to access online servics.\n",
+    "description": "UAF client for FIDO.\nFido is a set of open technical specifications for mechanisms of authenticating users to online services that do not depend on passwords.\nhttps://fidoalliance.org/specs/u2f-specs-1.0-bt-nfc-id-amendment/fido-glossary.html\nhttps://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-overview-v2.0-rd-20170927.html\nThe UAF protocol is designed to enable online services to offer passwordless and multi-factor security by allowing users to register their device to the online service and using a local authentication mechanism such as iris or fingerprint recognition.\nhttps://developers.google.com/identity/fido/android/native-apps\nSafe to remove if you don't use password-less authentification to access online services.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15779,11 +16256,11 @@
   {
     "id": "com.xiaomi.bluetooth.overlay",
     "list": "Oem",
-    "description": "MIUI Bluetooth Bluetooth Control. \nYou need to keep this if you want the bluetooth to work \n",
+    "description": "MIUI Bluetooth Bluetooth Control.\nYou need to keep this if you want the bluetooth to work.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.xiaomi.bsp.gps.nps",
@@ -15806,7 +16283,7 @@
   {
     "id": "com.miui.global.packageinstaller",
     "list": "Oem",
-    "description": "The security check / virus scan which runs after a package installation\nUninstalling it does not cause a bootloop\nPackage installation still works fine\n",
+    "description": "The security check / virus scan that runs after package installation.\nDisabling does not cause a bootloop and package installation still works fine.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -15950,11 +16427,11 @@
   {
     "id": "com.asus.calculator",
     "list": "Oem",
-    "description": "Asus calculator app\nNOTE : Simple calculator is a good alternative : https://f-droid.org/en/packages/com.simplemobiletools.calculator/\n",
+    "description": "Asus calculator app",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.asus.ia.asusapp",
@@ -15968,11 +16445,11 @@
   {
     "id": "com.asus.soundrecorder",
     "list": "Oem",
-    "description": "Asus Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder) \n",
+    "description": "Asus Sound recorder (https://play.google.com/store/apps/details?id=com.asus.soundrecorder)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.hotwordenrollment.xgoogle",
@@ -15995,7 +16472,7 @@
   {
     "id": "com.android.chrome",
     "list": "Google",
-    "description": "Google Chrome app (https://play.google.com/store/apps/details?id=com.android.chrome)\n",
+    "description": "Google Chrome (https://play.google.com/store/apps/details?id=com.android.chrome)\nOccasionally runs in the background.\nJust use Firefox instead, it's FOSS and functionally superior.. not that it's a high bar to clear when Chrome on Android has been slowly getting worse over the last few years.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16094,7 +16571,7 @@
   {
     "id": "com.google.android.apps.chromecast.app",
     "list": "Google",
-    "description": "Google Home (https://play.google.com/store/apps/details?id=com.google.android.apps.chromecast.app_US)\n",
+    "description": "Google Home (https://play.google.com/store/apps/details?id=com.google.android.apps.chromecast.app)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16112,7 +16589,7 @@
   {
     "id": "com.google.android.apps.cultural",
     "list": "Google",
-    "description": "Google Arts & Culture (https://play.google.com/store/apps/details?id=com.google.android.apps.cultural_US)\n",
+    "description": "Google Arts & Culture (https://play.google.com/store/apps/details?id=com.google.android.apps.cultural)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16130,7 +16607,7 @@
   {
     "id": "com.google.android.apps.docs",
     "list": "Google",
-    "description": "Google Drive (https://play.google.com/store/apps/details?id=com.google.android.apps.docs_US)\n",
+    "description": "Google Drive (https://play.google.com/store/apps/details?id=com.google.android.apps.docs)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16148,7 +16625,7 @@
   {
     "id": "com.google.android.apps.docs.editors.sheets",
     "list": "Google",
-    "description": "Google sheets\n",
+    "description": "Google Sheets (https://play.google.com/store/apps/details?id=com.google.android.apps.docs.editors.sheets)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16157,7 +16634,7 @@
   {
     "id": "com.google.android.apps.docs.editors.slides",
     "list": "Google",
-    "description": "Google slides (for presentation)\n",
+    "description": "Google Slides (https://play.google.com/store/apps/details?id=com.google.android.apps.docs.editors.slides)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16166,7 +16643,7 @@
   {
     "id": "com.google.android.apps.dynamite",
     "list": "Google",
-    "description": "Hangout chat (https://play.google.com/store/apps/details?id=com.google.android.apps.dynamite)\n",
+    "description": "Hangout chat (discontinued) (https://play.google.com/store/apps/details?id=com.google.android.apps.dynamite)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16229,7 +16706,7 @@
   {
     "id": "com.google.android.apps.googleassistant",
     "list": "Google",
-    "description": "Google Assistant (https://play.google.com/store/apps/details?id=com.google.android.apps.googleassistant_US)\n",
+    "description": "Google Assistant (https://play.google.com/store/apps/details?id=com.google.android.apps.googleassistant)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16256,7 +16733,7 @@
   {
     "id": "com.google.android.apps.kids.familylink",
     "list": "Google",
-    "description": "Inbox by Gmail (Discontinued)\nGoogle Family Link (https://play.google.com/store/apps/details?id=com.google.android.apps.kids.familylink)\n",
+    "description": "Google Family Link (https://play.google.com/store/apps/details?id=com.google.android.apps.kids.familylink)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16301,7 +16778,7 @@
   {
     "id": "com.google.android.apps.meetings",
     "list": "Google",
-    "description": "Hangout Meet (https://play.google.com/store/apps/details?id=com.google.android.apps.meetings)\n",
+    "description": "Hangout Meet (discontinued) (https://play.google.com/store/apps/details?id=com.google.android.apps.meetings)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16310,7 +16787,7 @@
   {
     "id": "com.google.android.apps.messaging",
     "list": "Google",
-    "description": "Google Messaging (SMS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\n",
+  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16319,7 +16796,7 @@
   {
     "id": "com.google.android.apps.nbu.files",
     "list": "Google",
-    "description": "Google Maps GPS (https://play.google.com/store/apps/details?id=com.google.android.apps.navlite)\nFile Management (https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files)\n",
+    "description": "Files by Google (https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files)\nRuns in the background.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16337,16 +16814,16 @@
   {
     "id": "com.google.android.apps.pdfviewer",
     "list": "Google",
-    "description": "Google PDF Viewer (https://play.google.com/store/apps/details?id=com.google.android.apps.pdfviewer)\n",
+    "description": "Google PDF Viewer\nShouldn't run in the background, so no reason to disable.\nDiscontinued, but still works perfectly on Android 11. In fact, this is the best standalone PDF-viewer I've found. The default PDF-viewer in recent Android releases is now integrated into Google Drive.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.apps.photos",
     "list": "Google",
-    "description": "Google photos (https://play.google.com/store/apps/details?id=com.google.android.apps.photos)\n",
+    "description": "Google Photos (https://play.google.com/store/apps/details?id=com.google.android.apps.photos)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16355,7 +16832,7 @@
   {
     "id": "com.google.android.apps.photos.scanner",
     "list": "Google",
-    "description": "PhotoScan app (https://play.google.com/store/apps/details?id=com.google.android.apps.photos.scanner)\n",
+    "description": "Google PhotoScan (https://play.google.com/store/apps/details?id=com.google.android.apps.photos.scanner)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16364,7 +16841,7 @@
   {
     "id": "com.google.android.apps.plus",
     "list": "Google",
-    "description": "Google+ (https://play.google.com/store/apps/details?id=com.google.android.apps.plus_US)\n",
+    "description": "Google+ (discontinued)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16382,7 +16859,7 @@
   {
     "id": "com.google.android.apps.restore",
     "list": "Google",
-    "description": "This is the backup restore wizard used for pulling Android system backups from your Google account. \nYou only need this if you factory restore the phone, in which case it’s automatically reinstalled for you.\n",
+    "description": "The backup restore wizard used for pulling Android system backups from your Google account.\nRuns on boot.\nYou only need this if you factory restore, in which case it’s automatically re-enabled for you.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16391,7 +16868,7 @@
   {
     "id": "com.google.android.apps.recorder",
     "list": "Google",
-    "description": "Google (audio) recorder (https://play.google.com/store/apps/details?id=com.google.android.apps.recorder)\n",
+    "description": "Google (audio)Recorder (https://play.google.com/store/apps/details?id=com.google.android.apps.recorder)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16400,7 +16877,7 @@
   {
     "id": "com.google.android.apps.setupwizard.searchselector",
     "list": "Google",
-    "description": "Most likely add a search bar to the setupwizard (com.google.android.setupwizard)\n",
+    "description": "Search engine selector\nThe search selection screen in the setupwizard you see on new/factory reset phones.\nRuns on boot, but doesn't seem to run in the background beyond that.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16409,7 +16886,7 @@
   {
     "id": "com.google.android.apps.santatracker",
     "list": "Google",
-    "description": "Google Santa Tracker WTF ??? (https://play.google.com/store/apps/details?id=com.google.android.apps.santatracker)\n",
+    "description": "Google Santa Tracker (discontinued)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16418,7 +16895,7 @@
   {
     "id": "com.google.android.apps.subscriptions.red",
     "list": "Google",
-    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red_US)\n",
+    "description": "Google One (https://play.google.com/store/apps/details?id=com.google.android.apps.subscriptions.red)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16557,7 +17034,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.calculator",
@@ -16580,11 +17057,11 @@
   {
     "id": "com.google.android.configupdater",
     "list": "Google",
-    "description": "Related to carrier config\nAuto updates certificates for TLS connection, firewall configuration, time zone info...\nSee : https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/os/ConfigUpdate.java\nThis is configuration stuff for Google services only.\n",
+    "description": "ConfigUpdater\nOccasionally runs in the background.\nAuto updates certificates for TLS connection, firewall configuration, e.t.c.\nMainly used for Google services? Might be fine to disable if you don't use Google services. Disabling might mess with security if you do use them though.\nhttps://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/os/ConfigUpdate.java",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.deskclock",
@@ -16598,16 +17075,16 @@
   {
     "id": "com.google.android.feedback",
     "list": "Google",
-    "description": "When an app crashes, this is the app that briefly asks you if you want to feedback the crash on the market, Google Play Store.\n",
+    "description": "This is the package that sends crash-report feedback to the Play Store? The crash pop-up still happens with this disabled.\nDoesn't seem to run on its own.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.googlequicksearchbox",
     "list": "Google",
-    "description": "Google Search box (https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox)\n",
+    "description": "Google Search box (https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox)\nRuns in the background.\nPointless. If you need a shortcut to Google on your homescreen just use a web-browser shortcut. Does also remove the Google Sound Search widget, but you can get that functionality from an app like Shazam, that additionally doesn't run in the background constantly like this package does.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16652,7 +17129,7 @@
   {
     "id": "com.google.android.music",
     "list": "Google",
-    "description": "Google Play Music (https://play.google.com/store/apps/details?id=com.google.android.music)\n",
+    "description": "Google Play Music (discontinued) (https://play.google.com/store/apps/details?id=com.google.android.music)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16679,7 +17156,7 @@
   {
     "id": "com.google.android.printservice.recommendation",
     "list": "Google",
-    "description": "Print recommendation service. \nNot clear, seems to help you to find printers but it's not mandatory. \nSafe to remove\n",
+    "description": "I think this has to do with recommending a printservice app you can get from the Play store.\nI think printing still works with this off.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16688,7 +17165,7 @@
   {
     "id": "com.google.android.projection.gearhead",
     "list": "Google",
-    "description": "Android auto (https://play.google.com/store/apps/details?id=com.google.android.projection.gearhead)\n",
+    "description": "Android Auto (https://play.google.com/store/apps/details?id=com.google.android.projection.gearhead)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16737,7 +17214,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.syncadapters.contacts",
@@ -16746,7 +17223,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.talk",
@@ -16760,7 +17237,7 @@
   {
     "id": "com.google.android.tts",
     "list": "Google",
-    "description": "Text-to-speech (https://play.google.com/store/apps/details?id=com.google.android.tts)\nPowers apps to read text on your scream aloud, in many languages\n",
+    "description": "Speech Services by Google (https://play.google.com/store/apps/details?id=com.google.android.tts)\nLets apps read text on your screen aloud, in many languages.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16787,7 +17264,7 @@
   {
     "id": "com.google.android.videos",
     "list": "Google",
-    "description": "Google Play Movies & TV (https://play.google.com/store/apps/details?id=com.google.android.videos)\n",
+    "description": "Google TV (previously Google Play Movies & TV) (https://play.google.com/store/apps/details?id=com.google.android.videos)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16832,11 +17309,11 @@
   {
     "id": "com.google.ar.core",
     "list": "Google",
-    "description": "YouTube app (https://play.google.com/store/apps/details?id=com.google.android.youtube)\nGoogle Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\n",
+    "description": "Google Play Services for AR (Augmented Reality) (https://play.google.com/store/apps/details?id=com.google.ar.core)\nDisabling breaks some games that depend on it, like Pokemon GO.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.ar.lens",
@@ -16917,12 +17394,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.zxing.client.android",
     "list": "Google",
-    "description": "Google Barcode Scanner (Discontinued) (https://play.google.com/store/apps/details?id=com.google.zxing.client.android)\n",
+    "description": "Google Barcode Scanner (discontinued) (https://play.google.com/store/apps/details?id=com.google.zxing.client.android)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16931,7 +17408,7 @@
   {
     "id": "com.google.android.apps.maps",
     "list": "Google",
-    "description": "Google maps (https://play.google.com/store/apps/details?id=com.google.android.apps.maps)\n",
+    "description": "Google Maps (https://play.google.com/store/apps/details?id=com.google.android.apps.maps)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16940,16 +17417,16 @@
   {
     "id": "com.google.android.apps.nexuslauncher",
     "list": "Google",
-    "description": "Nexus Launcher (https://play.google.com/store/apps/details?id=com.google.android.apps.nexuslauncher)\nIt's basically the home screen, the way icons apps are organized and displayed.\nDON'T REMOVE THIS IF YOU DIDN'T INSTALL ANOTHER LAUNCHER ! \n",
+    "description": "Pixel Launcher (https://play.google.com/store/apps/details?id=com.google.android.apps.nexuslauncher)\nUsed to be called Nexus Launcher(back when Google's phones were called Nexus, not Pixel).\nA launcher is basically your homescreen.\nDON'T REMOVE IF YOU HAVEN'T INSTALLED ANOTHER LAUNCHER! Nova Launcher is usually the go-to custom launcher.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.apps.turbo",
     "list": "Google",
-    "description": "Device Health Services (discontinued ?)\nCalculates your remaining battery percentage based on your usage\nReviews for this app were... funny (https://www.reddit.com/r/google/comments/ajnbmh/the_reviews_for_device_health_services_are_quite/)\nNote: this app needs com.google.android.gms\n",
+    "description": "Device Health Services (discontinued?)\nCalculates remaining battery percentage based on usage.\nReviews for this app were... funny (https://www.reddit.com/r/google/comments/ajnbmh/the_reviews_for_device_health_services_are_quite/)\nNote: this app needs com.google.android.gms",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16958,16 +17435,16 @@
   {
     "id": "com.google.android.apps.work.oobconfig",
     "list": "Google",
-    "description": "Needs internet to fetchs enterprise and carrier lock config via internet.\nRun in background and is triggered when a SIM card is added/removed/replaced. \nIt also has Gcm receiver (Google Cloud Messaging receiver)\nHas a lot of permissions (16).\nTalks to websites providing SSL certificates.\nNeeds Google Play Services to work.\nhttps://www.hybrid-analysis.com/sample/71bcaf2e71d78665fc5bc53db39df5309f24dd4ecab6402cf6ca20027dc6ecad?environmentId=200\n",
+    "description": "Device Setup\nSets up device to be managed by EMM (Enterprise Mobility Management), which \"allows organizations to securely enable employee use of mobile devices\".\nMight also be what does the actual management on your device, if you set it up as a work device.\nOnly seems to run on boot(not in the background after boot) if you haven't set up your device as a work device.\nI tried to disable it through UAD, but nothing happens? Seems immune to disabling?\nhttps://bayton.org/2020/11/google-announce-big-changes-to-zero-touch/\nhttps://bayton.org/docs/enterprise-mobility/android/what-is-android-zero-touch-enrolment/\nContains 4 services: GcmJobService, GservicesChangedObserverService, AppMeasurementService and FirebaseInstanceIdService.\nGCM(Google Cloud Messaging) was the backend for Android's push messaging system 2012-2019, after which it was replaced by FCM(Firebase Cloud Messaging). I assume the GCM/Firebase connection is for Push notification functionality.\nThe MANAGE_CARRIER_OEM_UNLOCK_STATE permission hints at doing something with carrier locks?\nNeeds Google Play Services to function?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.carrierconfig",
     "list": "Google",
-    "description": "Provides network overrides for carrier configuration.\nThe configuration available through CarrierConfigManager is a combination of default values, default network overrides, \nand carrier overrides. The default network overrides are provided by this service.\nWhat's the difference between com.android.carrierconfig and this package?\n",
+    "description": "Same as com.android.carrierconfig? Here's that description:\nDynamically provides configuration for the carrier network.\nThe config contains: Roaming networks, Voicemail settings, SMS/MMS settings, VoLTE/IMS settings, and more.\nIf a carrier app is installed it will be queried for overrides to these settings.\nSeems to run on boot and when you swap SIM card?\nhttps://source.android.com/devices/tech/config/carrier\nhttps://cs.android.com/android/platform/superproject/+/master:packages/apps/CarrierConfig/src/com/android/carrierconfig/DefaultCarrierConfigService.java",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16976,16 +17453,16 @@
   {
     "id": "com.google.android.contacts",
     "list": "Google",
-    "description": "Google Contacts (https://play.google.com/store/apps/details?id=com.google.android.contacts)\n",
+    "description": "Google Contacts (https://play.google.com/store/apps/details?id=com.google.android.contacts)\nOccasionally runs in the background.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.dialer",
     "list": "Google",
-    "description": "Google Dialer (https://play.google.com/store/apps/details?id=com.google.android.dialer)\nIt's not default but seriously, don't use the Google dialer there are Google Analytics embedded inside\nhttps://www.virustotal.com/gui/file/a978d90f27d5947dca33ed59b73bd8efbac67253f9ef7a343beb9197c8913d1a/details\n",
+    "description": "Google Dialer (https://play.google.com/store/apps/details?id=com.google.android.dialer)\nDefault dialer on some phones.\nGoogle Analytics are embedded in the app, assume everything is datamined.\nhttps://www.virustotal.com/gui/file/a978d90f27d5947dca33ed59b73bd8efbac67253f9ef7a343beb9197c8913d1a/details",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -16994,16 +17471,16 @@
   {
     "id": "com.google.android.documentsui",
     "list": "Google",
-    "description": "Google File manager\n",
+    "description": "Files\nOccasionally runs in the background.\nFile selector for other apps. Another file browser can replace most of the functionality, but not all apps support that.\nSafe to disable, but will of course break file saving/loading functionality for some apps.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.ext.shared",
     "list": "Google",
-    "description": "Google shared library (used to share common code between apps)\nFor now the library (android.ext.shared is empty). So this apk is useless.",
+    "description": "Google shared library (used to share common code between apps)\nIt's empty, so this package is useless?",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17021,7 +17498,7 @@
   {
     "id": "com.google.android.gms",
     "list": "Google",
-    "description": "Google Play Services\ngms = Google Mobile Services\nIt is a layer that sits on top of the OS and provide a bunch of Google APIs, giving developers access to various Google Services.\nIf you remove it all the apps relying on Google Play Services whill either : \n- detect the lack of play services and refuse to run\n- detect the lack of play services but allow you to run (not properly) by dismissing a annoying popup\nWith some phones, removing Google Play Services bootloop the device so be careful.\nNOTE : Deleting this package will improve a LOT your battery life !\n#\nIMPORTANT : You need to uncheck Find My Device from the \"Device admin apps\" settings panel to be able to uninstall this package\nSearch \"admin\" in the settings search bar.\n",
+    "description": "Google Play Services\ngms = Google Mobile Services\nIt is a layer that sits on top of the OS and provides a bunch of Google APIs, giving apps access to various Google Services.\nIf you remove it all the apps relying on Google Play Services whill either: \n- detect the lack of play services and refuse to run\n- detect the lack of play services but allow you to run (improperly) by dismissing an annoying popup\nRemoving Google Play Services can bootloop some devices, so be careful.\nDisabling this package will improve battery life a lot.\nIMPORTANT: You need to uncheck Find My Device from the \"Device admin apps\" settings panel to be able to disable this package.\nSearch \"admin\" in the settings search bar.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17030,7 +17507,7 @@
   {
     "id": "com.google.android.overlay.gmsgsaconfig",
     "list": "Google",
-    "description": "Probably RROs (https://source.android.com/devices/architecture/rros?hl=en) tied to \"com.google.android.gms\" (Google Play Services)\nIf you remove com.google.android.gms you can remove those 2 packages as well.\n",
+    "description": "Overlay theme for gmsgsaconfig? Probably an RRO? https://source.android.com/devices/architecture/rros",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17039,7 +17516,7 @@
   {
     "id": "com.google.android.gms.location.history",
     "list": "Google",
-    "description": "Google Location history\nhttps://support.google.com/accounts/answer/3118687?hl=en\n",
+    "description": "Google Location history\nhttps://support.google.com/accounts/answer/3118687?hl=en\nI'm guessing this runs in the background unless you have this setting turned off in your Google account. I have the setting turned off and I've never seen this package run.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17048,16 +17525,16 @@
   {
     "id": "com.google.android.gms.policy_sidecar_aps",
     "list": "Google",
-    "description": "Talks to Gmail.com and Google.com.\nNeeds a Google Account and Google Play Services to work correctly.\nI don't know much more but it's sufficient to know you can debloat it.\nGiven its name maybe it is related to Android auto? \nhttps://www.hybrid-analysis.com/sample/c710b66d043026007666966d933e3a1ed29720c5009764c01b5f056232a3518a?environmentId=200\n",
+    "description": "Talks to Gmail.com and Google.com.\nNeeds a Google Account and Google Play Services to work correctly.\nI don't know much more but it's sufficient to know you can debloat it.\nGiven its name it could be related to Android auto?\nhttps://www.hybrid-analysis.com/sample/c710b66d043026007666966d933e3a1ed29720c5009764c01b5f056232a3518a?environmentId=200",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.google.android.gsf",
     "list": "Google",
-    "description": "Google Services Framework\nSupports the Play Services application in a variety of ways from application updates, user authentication, location services, user searches & more \nhttps://android.stackexchange.com/questions/216176/what-is-the-exact-functionality-of-google-play-services-google-services-framew\nhttps://stackoverflow.com/questions/37337448/what-is-the-difference-between-google-service-frameworkgsfgoogle-mobile-servi\nSame recommendation than com.google.android.gms except that I've never seen a bootloop because of deleting this package.\n",
+    "description": "Google Services Framework\nSupports the Play Services application in application updates, user authentication, location services, user searches & more.\nhttps://android.stackexchange.com/questions/216176/what-is-the-exact-functionality-of-google-play-services-google-services-framew\nhttps://stackoverflow.com/questions/37337448/what-is-the-difference-between-google-service-frameworkgsfgoogle-mobile-servi\nSame recommendation as com.google.android.gms except I've never seen a bootloop because of deleting this package.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17066,7 +17543,7 @@
   {
     "id": "com.google.android.gsf.login",
     "list": "Google",
-    "description": "Support for managing Google accounts\nSafe to remove if you don't use a Google account.\n",
+    "description": "Support for managing Google accounts.\nSafe to remove if you don't use a Google account.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17075,7 +17552,7 @@
   {
     "id": "com.google.android.location",
     "list": "Google",
-    "description": "Handles location services on older devices. On newer ones Google location services is part of Google Play Services and\nAndroid location service is provided by com.android.location.fused or com.android.location.\n",
+    "description": "Handles location services on older devices. On newer ones Google location services is part of Google Play Services and Android location service is provided by com.android.location.fused or com.android.location.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17084,7 +17561,7 @@
   {
     "id": "com.google.android.partnersetup",
     "list": "Google",
-    "description": "Enables applications to perform functionality that requires access to your Google account information\nSafe to remove if you don't have a Google account\n",
+    "description": "Google Partner Setup\nOccasionally runs in the background.\nBased on an unclear explanation online: Enables applications to interact with your Google account/apps, for example: adding a Google Calendar event from a To-Do app.\nProbably safe to disable; Haven't noticed any consequences of disabling from weeks of use.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17093,7 +17570,7 @@
   {
     "id": "com.google.android.webview",
     "list": "Google",
-    "description": "Android WebView is a system component for the Android operating system (OS) that allows Android apps to display content \nfrom the web directly inside an application. It's based on Chrome.\nOn open-source privacy oriented Webview is Bromite (https://www.bromite.org/system_web_view)\nhttps://play.google.com/store/apps/details?id=com.google.android.webview\n",
+    "description": "Android System WebView (https://play.google.com/store/apps/details?id=com.google.android.webview)\nAllows Android apps to display content from the web directly inside the app.\nBased on Chrome.\nBromite is an open-source, privacy-oriented Webview replacement: https://www.bromite.org/system_web_view",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17120,7 +17597,7 @@
   {
     "id": "com.google.android.ims",
     "list": "Google",
-    "description": "Carrier Services (for Google phones) (https://play.google.com/store/apps/details?id=com.google.android.ims)\nIMS is an open industry standard for voice and multimedia communications over packet-based IP networks (Volte/VoIP/Wifi calling).\n",
+    "description": "Carrier Services (https://play.google.com/store/apps/details?id=com.google.android.ims)\nRuns in the background.\nPlay store description claims power savings in addition to the features, but I don't see how that could be the case.\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling).",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17138,7 +17615,7 @@
   {
     "id": "com.android.vending",
     "list": "Google",
-    "description": "Google Play Store app",
+    "description": "Google Play Store",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17147,7 +17624,7 @@
   {
     "id": "com.google.android.inputmethod.latin",
     "list": "Google",
-    "description": "Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\n",
+    "description": "Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\nSometimes the only keyboard app on a phone; Make sure you have another installed before you disable.\n\"Simple Keyboard\" is a good lightweight replacement based on the AOSP Keyboard.\nhttps://f-droid.org/en/packages/rkr.simplekeyboard.inputmethod/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17201,20 +17678,29 @@
   {
     "id": "com.google.android.modulemetadata",
     "list": "Google",
-    "description": "Module that contains ... metadata about the list of modules on the device. And that’s about it.\nI wouldn't advise you to mess with it as it could break the proper working of other important modules (see #37)\nGood explanation of what android modules are : https://www.xda-developers.com/android-project-mainline-modules-explanation/\n",
+    "description": "Module that contains metadata about the list of modules on the device. And that’s about it.\nI wouldn't advise you to mess with it as it could break important modules (see #37)\nGood explanation of what android modules are : https://www.xda-developers.com/android-project-mainline-modules-explanation/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
     "removal": "Unsafe"
   },
   {
-    "id": "com.google.android.overlay.modules.ext.services",
+    "id": "com.google.android.ext.services",
     "list": "Google",
-    "description": "Android Services Library that contains an \"Android Notification Ranking Service.\" \nIt sorts notifications by \"importance\" based on things like freshness, app type (IM apps come first), and by contact. \nThe library android.ext.services is open-source. Google probably uses it to update its API without having to rely to the OEM\nIt is a mainline module and is needed to boot since Android 11! NO NOT REMOVE IT!\nhttps://source.android.com/devices/architecture/modular-system/extservices\nhttps://arstechnica.com/gadgets/2016/11/android-extensions-could-be-googles-plan-to-make-android-updates-suck-less/\n",
+    "description": "Android Services Library\nSome of these services are only present in newer versions of Android.\nContains: CacheQuotaService, LRResolverRankerService, AutofillFieldClassificationService, ExplicitHealthCheckService, DefaultTextClassifierService, ModelDownloaderService, InlineSuggestionRenderService, DisplayHashingService, SystemJobService, SystemForegroundService, MutliInstanceInvalidationService and runs \"Notification Assistant\" service in the background by default, which moves notifications up or down depending on importance. That service can be disabled by selecting \"None\" under \"Adaptive Notifications\", without impacting other potentially important functionality contained in the package. NOTE: This setting is stored in RAM and resets on reboot.\nNoticed no negative effects from disabling the package in Android 9 nor 11 on Oneplus phones, but would still advise caution as some of the service names sound important.\nhttps://source.android.com/devices/architecture/modular-system/extservices\nhttps://arstechnica.com/gadgets/2016/11/android-extensions-could-be-googles-plan-to-make-android-updates-suck-less/",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Unsafe"
+    "removal": "Expert"
+  },
+  {
+    "id": "com.google.android.overlay.modules.ext.services",
+    "list": "Google",
+    "description": "Android System Theme pack\nThe package name is pretty self-explanatory.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.networkstack",
@@ -17235,6 +17721,15 @@
     "removal": "Unsafe"
   },
   {
+    "id": "com.google.android.packageinstaller",
+    "list": "Google",
+    "description": "Occasionally runs in the background.\nRelated to installing Google-specific packages? Possibly something to do with Play services and backend updates/installations. Installing an app through Google Play worked fine with it disabled.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
     "id": "com.google.android.packageinstaller.a_overlay",
     "list": "Google",
     "description": "Gives ability to install, update or remove applications on the device.\nIf you delete this package, your phone will probably bootloop.\n",
@@ -17244,9 +17739,27 @@
     "removal": "Unsafe"
   },
   {
+    "id": "com.google.android.permissioncontroller",
+    "list": "Google",
+    "description": "Permission controller\nControls app permissions.\nhttps://source.android.com/devices/architecture/modular-system/permissioncontroller",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.google.android.overlay.modules.permissioncontroller",
+    "list": "Google",
+    "description": "Permission controller Theme pack\nGuessing it's a pack of themes for the Permission Controller based on the name.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
     "id": "com.google.android.overlay.modules.permissioncontroller.forframework",
     "list": "Google",
-    "description": "The PermissionController module enables updatable privacy policies and UI elements.\nFor example, the policies and UI around granting and managing permissions.\nhttps://source.android.com/devices/architecture/modular-system/permissioncontroller\n",
+    "description": "Android System Theme pack\nGuessing it's a pack of themes for the Android system framework permission controller based on the name.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -17358,25 +17871,25 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.AprUploadService.data.overlay.base",
     "list": "Oem",
-    "description": "Apr Upload Service ???? [MORE INFO NEEDED]",
+    "description": "Theme overlay for Apr Upload Service?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.AprUploadService.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Apr Upload Service ???? [MORE INFO NEEDED]",
+    "description": "Theme overlay for Apr Upload Service?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.autoregistration",
@@ -17390,7 +17903,7 @@
   {
     "id": "com.evenwell.autoregistration.overlay.base",
     "list": "Oem",
-    "description": "Spyware app which sends warranty details to China\nhttps://milankragujevic.com/the-trade-of-privacy-for-convenience\nhttps://nitter.net/drwetter/status/1108801189662130176",
+    "description": "Theme overlay for a Spyware app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17399,7 +17912,7 @@
   {
     "id": "com.evenwell.autoregistration.overlay.base.s600id",
     "list": "Oem",
-    "description": "Spyware app which sends warranty details to China\nhttps://milankragujevic.com/the-trade-of-privacy-for-convenience\nhttps://nitter.net/drwetter/status/1108801189662130176",
+    "description": "Theme overlay for a Spyware app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17408,7 +17921,7 @@
   {
     "id": "com.evenwell.autoregistration.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Spyware app which sends warranty details to China\nhttps://milankragujevic.com/the-trade-of-privacy-for-convenience\nhttps://nitter.net/drwetter/status/1108801189662130176",
+    "description": "Theme overlay for a Spyware app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17417,7 +17930,7 @@
   {
     "id": "com.evenwell.autoregistration.overlay.d.base.s600id",
     "list": "Oem",
-    "description": "Spyware app which sends warranty details to China\nhttps://milankragujevic.com/the-trade-of-privacy-for-convenience\nhttps://nitter.net/drwetter/status/1108801189662130176",
+    "description": "Theme overlay for a Spyware app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17435,29 +17948,29 @@
   {
     "id": "com.evenwell.batteryprotect.overlay.base",
     "list": "Oem",
-    "description": "Battery protect is advertised to improve battery performance but in practice it drains your battery and kills apps to aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/\n",
+    "description": "Theme overlay for Battery Protect?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600id",
     "list": "Oem",
-    "description": "Battery protect is advertised to improve battery performance but in practice it drains your battery and kills apps to aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/\n",
+    "description": "Theme overlay for Battery Protect?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.batteryprotect.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Battery protect is advertised to improve battery performance but in practice it drains your battery and kills apps to aggressively.\nhttps://dontkillmyapp.com/nokia\nNokia decided to stop using this app-killer in the future\nhttps://www.androidpolice.com/2019/08/27/nokia-hmd-phones-disable-evenwell-background-process-app-killer/\n",
+    "description": "Theme overlay for Battery Protect?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.bboxsbox",
@@ -17471,11 +17984,11 @@
   {
     "id": "com.evenwell.bokeheditor",
     "list": "Oem",
-    "description": "Related to photos editing I think [MORE INFO NEEDED]",
+    "description": "Probably related to adding fake bokeh (a focus blur effect) to photos.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.CPClient",
@@ -17484,25 +17997,25 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base",
     "list": "Oem",
-    "description": "CP = Client Provisioning.\nSurely used to push new carrier internet/MMS settings automatically\nMaybe it's useful if carriers change their APN... but you still can change it manually, it's not difficult.\n",
+    "description": "Theme overlay for CPClient?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.CPClient.overlay.base.s600id",
     "list": "Oem",
-    "description": "CP = Client Provisioning.\nSurely used to push new carrier internet/MMS settings automatically\nMaybe it's useful if carriers change their APN... but you still can change it manually, it's not difficult.\n",
+    "description": "Theme overlay for CPClient?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager",
@@ -17511,84 +18024,84 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base",
     "list": "Oem",
-    "description": "Customer manager\nGiven its name I'd say it is useless but I don't have more info.\n",
+    "description": "Theme overlay for Customer Manager?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600id",
     "list": "Oem",
-    "description": "Customer manager\nGiven its name I'd say it is useless but I don't have more info.\n",
+    "description": "Theme overlay for Customer Manager?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.custmanager.data.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Customer manager\nGiven its name I'd say it is useless but I don't have more info.\n",
+    "description": "Theme overlay for Customer Manager?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent",
     "list": "Oem",
-    "description": "",
+    "description": "Data agent\nUsed for backup/restore? [MORE INFO NEEDED]",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base",
     "list": "Oem",
-    "description": "Data agent\nUsed for backup/restore ? [MORE INFO NEEDED]",
+    "description": "Theme overlay for Data Agent?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.dataagent.overlay.base.s600id",
     "list": "Oem",
-    "description": "Data agent\nUsed for backup/restore ? [MORE INFO NEEDED]",
+    "description": "Theme overlay for Data Agent?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DbgCfgTool",
     "list": "Oem",
-    "description": "",
+    "description": "Debug Config Tool?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base",
     "list": "Oem",
-    "description": "Debug config tool ? # [MORE INFO NEEDED]",
+    "description": "Theme overlay for Debug Config Tool?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.DbgCfgTool.overlay.base.s600id",
     "list": "Oem",
-    "description": "Debug config tool ? # [MORE INFO NEEDED]",
+    "description": "Theme overlay for Debug Config Tool?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17597,16 +18110,16 @@
   {
     "id": "com.evenwell.DeviceMonitorControl",
     "list": "Oem",
-    "description": "Monitor stuff obviously...",
+    "description": "Some form of device monitoring?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.DeviceMonitorControl.data.overlay.base",
     "list": "Oem",
-    "description": "Monitor stuff obviously...",
+    "description": "Theme overlay for Device Monitor Control?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17615,7 +18128,7 @@
   {
     "id": "com.evenwell.DeviceMonitorControl.data.overlay.base.s600id",
     "list": "Oem",
-    "description": "Monitor stuff obviously...",
+    "description": "Theme overlay for Device Monitor Control?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17624,7 +18137,7 @@
   {
     "id": "com.evenwell.factorywizard",
     "list": "Oem",
-    "description": "Most likely a configuration setup after a factory reset (and/or after first boot)\nGuides you through the basics of setting up your device.",
+    "description": "Likely part of the first-boot device setup (new/factory reset device).",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17633,7 +18146,7 @@
   {
     "id": "com.evenwell.factorywizard.overlay.base",
     "list": "Oem",
-    "description": "Most likely a configuration setup after a factory reset (and/or after first boot)\nGuides you through the basics of setting up your device.",
+    "description": "Theme overlay for setup wizard?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17651,16 +18164,16 @@
   {
     "id": "com.evenwell.managedprovisioning",
     "list": "Oem",
-    "description": "Seems to be a user interface related to settings description and wizard setup.\nhttps://en.wikipedia.org/wiki/Wizard_(software)",
+    "description": "Nokia implementation of com.android.managedprovisioning? If so it manages Android user accounts, allowing you to add extra accounts. The typical use-case is setting up a corporate profile that is controlled by the employer on an employee's personal device, to keep personal and work data separate.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.managedprovisioning.overlay.base",
     "list": "Oem",
-    "description": "Seems to be a user interface related to settings description and wizard setup.\nhttps://en.wikipedia.org/wiki/Wizard_(software)",
+    "description": "Theme overlay for Managed Provisioning?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17669,7 +18182,7 @@
   {
     "id": "com.evenwell.managedprovisioning.overlay.base.s600id",
     "list": "Oem",
-    "description": "Seems to be a user interface related to settings description and wizard setup.\nhttps://en.wikipedia.org/wiki/Wizard_(software)",
+    "description": "Theme overlay for Managed Provisioning?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17687,7 +18200,7 @@
   {
     "id": "com.evenwell.nps.overlay.base",
     "list": "Oem",
-    "description": "Net Promoter Score\nPreinstalled survey.",
+    "description": "Theme overlay for Net Promoter Score?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17696,7 +18209,7 @@
   {
     "id": "com.evenwell.nps.overlay.base.s600id",
     "list": "Oem",
-    "description": "Net Promoter Score\nPreinstalled survey.",
+    "description": "Theme overlay for Net Promoter Score?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17714,7 +18227,7 @@
   {
     "id": "com.evenwell.partnerbrowsercustomizations",
     "list": "Oem",
-    "description": "",
+    "description": "Adds something partner-related to your browser? Probably adds bookmarks.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17723,7 +18236,7 @@
   {
     "id": "com.evenwell.partnerbrowsercustomizations.overlay.base",
     "list": "Oem",
-    "description": "Customize your browser with stuff you don't want.",
+    "description": "Theme overlay for some browser customization?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17732,7 +18245,7 @@
   {
     "id": "com.evenwell.partnerbrowsercustomizations.overlay.base.s600id",
     "list": "Oem",
-    "description": "Customize your browser with stuff you don't want.",
+    "description": "Theme overlay for some browser customization?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17745,16 +18258,16 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.phone.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for the dialer app",
+    "description": "Theme overlay for the dialer app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.PowerMonitor",
@@ -17768,7 +18281,7 @@
   {
     "id": "com.evenwell.PowerMonitor.overlay.base",
     "list": "Oem",
-    "description": "Drains more battery than it saves.",
+    "description": "Theme overlay for Power Monitor?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17777,7 +18290,7 @@
   {
     "id": "com.evenwell.PowerMonitor.overlay.base.s600id",
     "list": "Oem",
-    "description": "Drains more battery than it saves.",
+    "description": "Theme overlay for Power Monitor?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17786,16 +18299,16 @@
   {
     "id": "com.evenwell.providers.downloads.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Add most likey a useless overlay on the download app.",
+    "description": "Theme overlay for the downloads app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.providers.weather",
     "list": "Oem",
-    "description": "Provider for the Nokia weather app.\nREMINDER : Content providers help an application manage access to data stored by itself, stored by other apps, \nand provide a way to share data with other apps. They encapsulate the data, and provide mechanisms for defining data security\nSource : https://developer.android.com/guide/topics/providers/content-providers.html\n",
+    "description": "Provider for the Nokia weather app.\nContent providers encapsulate data, providing centralized management of data shared between apps.\nhttps://developer.android.com/guide/topics/providers/content-providers.html",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17804,7 +18317,7 @@
   {
     "id": "com.evenwell.pushagent",
     "list": "Oem",
-    "description": "Surely related to push notifications for Nokia apps (only ?)\n",
+    "description": "Related to push notifications for Nokia apps?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17813,20 +18326,20 @@
   {
     "id": "com.evenwell.pushagent.overlay.base",
     "list": "Oem",
-    "description": "Surely related to push notifications for Nokia apps (only ?)\n",
+    "description": "Theme overlay for pushagent?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.pushagent.overlay.base.s600id",
     "list": "Oem",
-    "description": "Surely related to push notifications for Nokia apps (only ?)\n",
+    "description": "Theme overlay for pushagent?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.retaildemoapp",
@@ -17840,7 +18353,7 @@
   {
     "id": "com.evenwell.retaildemoapp.overlay.base",
     "list": "Oem",
-    "description": "Nokia retail demonstration mode\nhttps://en.wikipedia.org/wiki/Demo_mode",
+    "description": "Theme overlay for Nokia retail demonstration mode?\nhttps://en.wikipedia.org/wiki/Demo_mode",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17849,7 +18362,7 @@
   {
     "id": "com.evenwell.retaildemoapp.overlay.base.s600id",
     "list": "Oem",
-    "description": "Nokia retail demonstration mode\nhttps://en.wikipedia.org/wiki/Demo_mode",
+    "description": "Theme overlay for Nokia retail demonstration mode?\nhttps://en.wikipedia.org/wiki/Demo_mode",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17862,7 +18375,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.SettingsUtils",
@@ -17876,7 +18389,7 @@
   {
     "id": "com.evenwell.SetupWizard",
     "list": "Oem",
-    "description": "It's the basic configuration wizard that drives you through first boot and guides you through the basics of setting up your device.\n",
+    "description": "The first-boot device setup wizard for new/factory reset devices.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17885,7 +18398,7 @@
   {
     "id": "com.evenwell.SetupWizard.overlay.base",
     "list": "Oem",
-    "description": "It's the basic configuration wizard that drives you through first boot and guides you through the basics of setting up your device.\n",
+    "description": "Theme overlay for Setup Wizard?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17894,7 +18407,7 @@
   {
     "id": "com.evenwell.setupwizard.btl.s600ww.overlay",
     "list": "Oem",
-    "description": "It's the basic configuration wizard that drives you through first boot and guides you through the basics of setting up your device.\n",
+    "description": "Theme overlay for Setup Wizard?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17903,7 +18416,7 @@
   {
     "id": "com.evenwell.SetupWizard.overlay.d.base.s600ww",
     "list": "Oem",
-    "description": "It's the basic configuration wizard that drives you through first boot and guides you through the basics of setting up your device.\n",
+    "description": "Theme overlay for Setup Wizard?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17912,7 +18425,7 @@
   {
     "id": "com.evenwell.stbmonitor",
     "list": "Oem",
-    "description": "Apparently used to stabilize phone usage.\nSeems to drain battery \n",
+    "description": "Apparently used to stabilize phone usage.\nSeems to drain battery.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17921,7 +18434,7 @@
   {
     "id": "com.evenwell.stbmonitor.data.overlay.base",
     "list": "Oem",
-    "description": "Apparently used to stabilize phone usage.\nSeems to drain battery \n",
+    "description": "Theme overlay for STB Monitor?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17930,7 +18443,7 @@
   {
     "id": "com.evenwell.stbmonitor.data.overlay.base.s600id",
     "list": "Oem",
-    "description": "Apparently used to stabilize phone usage.\nSeems to drain battery \n",
+    "description": "Theme overlay for STB Monitor?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17939,7 +18452,7 @@
   {
     "id": "com.evenwell.telecom.data.overlay.base",
     "list": "Oem",
-    "description": "Telecom telemetry ? [MORE INFO NEEDED]",
+    "description": "Overlay related to Telecom data? Overlays are usually themes.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17948,7 +18461,7 @@
   {
     "id": "com.evenwell.telecom.data.overlay.base.s600id",
     "list": "Oem",
-    "description": "Telecom telemetry ? [MORE INFO NEEDED]",
+    "description": "Theme overlay for something telecom-related?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17961,12 +18474,12 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.evenwell.UsageStatsLogReceiver.data.overlay.back.s600id",
     "list": "Oem",
-    "description": "Logging stuff",
+    "description": "Theme overlay for Usage Stats Log?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -17975,11 +18488,11 @@
   {
     "id": "com.evenwell.weather.overlay.base.s600ww",
     "list": "Oem",
-    "description": "Overlay for the weather app [MORE INFO NEEDED]",
+    "description": "Theme overlay for the Nokia weather app?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   {
     "id": "com.evenwell.weatherservice",
@@ -17988,12 +18501,12 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.hmdglobal.datago",
     "list": "Oem",
-    "description": "Sends diagnostic data to HMD (Company behind Nokia) ?",
+    "description": "Sends diagnostic data to HMD (Company behind Nokia)?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18002,7 +18515,7 @@
   {
     "id": "com.hmdglobal.datago.overlay.base",
     "list": "Oem",
-    "description": "Sends diagnostic data to HMD (Company behind Nokia) ?",
+    "description": "Theme overlay for this telemetry package?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18146,11 +18659,11 @@
   {
     "id": "com.samsung.hiddennetworksetting",
     "list": "Oem",
-    "description": "Set of hidden network settings (inlcuding frequency bands choice)\nHow to see these settings : https://forum.xda-developers.com/galaxy-note-8/help/q-hidden-network-settings-pie-t3914421/page4",
+    "description": "Set of hidden network settings (inlcuding frequency band choice).\nHow to see these settings: https://forum.xda-developers.com/galaxy-note-8/help/q-hidden-network-settings-pie-t3914421/page4",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.systemui.bixby",
@@ -18387,33 +18900,6 @@
     "removal": "Recommended"
   },
   {
-    "id": "android.autoinstalls.config.Xiaomi.cepheus",
-    "list": "Oem",
-    "description": "android.autoinstalls.config.Xiaomi.X where X is the phone's codename\nUsed to **auto** install stuff\nIMO it's a similar feature than Play Auto Install (https://forum.xda-developers.com/xperia-z/help/how-stop-google-play-auto-install-t2590253)\n",
-    "dependencies": null,
-    "neededBy": "",
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
-    "id": "android.autoinstalls.config.Xiaomi.dipper",
-    "list": "Oem",
-    "description": "android.autoinstalls.config.Xiaomi.X where X is the phone's codename\nUsed to **auto** install stuff\nIMO it's a similar feature than Play Auto Install (https://forum.xda-developers.com/xperia-z/help/how-stop-google-play-auto-install-t2590253)\n",
-    "dependencies": null,
-    "neededBy": "",
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
-    "id": "android.autoinstalls.config.Xiaomi.daisy",
-    "list": "Oem",
-    "description": "android.autoinstalls.config.Xiaomi.X where X is the phone's codename\nUsed to **auto** install stuff\nIMO it's a similar feature than Play Auto Install (https://forum.xda-developers.com/xperia-z/help/how-stop-google-play-auto-install-t2590253)\n",
-    "dependencies": null,
-    "neededBy": "",
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
     "id": "com.miui.miwallpaper.earth",
     "list": "Oem",
     "description": "SuperWallpaperEARTH / SuperWallpaperMARS\nLive/animated Xiaomi wallaper",
@@ -18461,7 +18947,7 @@
   {
     "id": "com.google.android.setupwizard",
     "list": "Google",
-    "description": "It's the basic configuration setup guides you through the basics of setting up Google features on your device.\nThe second package is only present on Pixel phones.",
+    "description": "Android Setup\nThe new/factory reset device basic configuration setup guides you through the basics of setting up your device.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18470,7 +18956,7 @@
   {
     "id": "com.google.android.setupwizard.a_overlay",
     "list": "Google",
-    "description": "It's the basic configuration setup guides you through the basics of setting up Google features on your device.\nThe second package is only present on Pixel phones.",
+    "description": "Overlay for setupwizard?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18479,7 +18965,7 @@
   {
     "id": "com.google.android.youtube",
     "list": "Google",
-    "description": "YouTube app (https://play.google.com/store/apps/details?id=com.google.android.youtube)",
+    "description": "YouTube (https://play.google.com/store/apps/details?id=com.google.android.youtube)",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18488,7 +18974,7 @@
   {
     "id": "com.google.android.email",
     "list": "Google",
-    "description": "AOSP Mail client\nDoes no longer exist. AOSP Mail is now com.android.email and Gmail is com.google.android.gm",
+    "description": "AOSP Mail client\nNewer versions of AOSP Mail are renamed to com.android.email and Gmail was migrated to com.google.android.gm",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18585,15 +19071,6 @@
     "removal": "Recommended"
   },
   {
-    "id": "com.roaming.android.gsimbase",
-    "list": "Misc",
-    "description": "GSIM = Generic Statistical Information Model ? I don't think so but I can't find anything.",
-    "dependencies": null,
-    "neededBy": "",
-    "labels": null,
-    "removal": "Recommended"
-  },
-  {
     "id": "com.til.timesnews",
     "list": "Misc",
     "description": "India News (https://play.google.com/store/apps/details?id=com.til.timesnews)",
@@ -18641,7 +19118,7 @@
   {
     "id": "com.dsi.ant.plugins.antplus",
     "list": "Misc",
-    "description": " ANT+ plugin service (https://play.google.com/store/apps/details?id=com.dsi.ant.plugins.antplus)",
+    "description": "ANT+ plugin service (https://play.google.com/store/apps/details?id=com.dsi.ant.plugins.antplus)",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18650,11 +19127,11 @@
   {
     "id": "com.android.bips",
     "list": "Aosp",
-    "description": "Default print Service.",
+    "description": "Default Print Service.\nGeneric printing service that should work with most printers.\nWill break printing functionality if disabled, but other replacement print services can be downloaded from the Play Store.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.android.email.partnerprovider",
@@ -18672,7 +19149,7 @@
     "dependencies": null,
     "neededBy": "",
     "labels": null,
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.cameraxservice",
@@ -18686,7 +19163,7 @@
   {
     "id": "com.samsung.android.kgclient",
     "list": "Pending",
-    "description": "Samsung Pay One Ui 3.0 ?",
+    "description": "Samsung Pay One Ui 3.0?",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18731,7 +19208,7 @@
   {
     "id": "com.lge.signboard",
     "list": "Oem",
-    "description": "Always on display. Probably a battery killer if used without OLED screen.\nYou will lose the menu in the settings app that allows you to set the always on display. From the top of my head I remember the default ones as clock, kitkat easter egg.",
+    "description": "Always On Display.\nProbably a battery killer without an OLED screen.\nDisabling will remove the connected menu in the settings app.",
     "dependencies": null,
     "neededBy": "",
     "labels": null,
@@ -18830,7 +19307,7 @@
   {
     "id": "uk.co.ee.myee",
     "list": "Carrier",
-    "description": "Myee app (https://play.google.com/store/apps/details?id=uk.co.ee.myee)\nLets you control your EE pay monthly, pay as you go and WiFi devices. Check your data, bills, packs and more, and keep an eye on your spending.\nContains unwanted analytics and most of the things the app does can be done by texting 150 from your mobile.\nSee https://ee.co.uk/help/help-new/billing-usage-and-top-up/call-text-and-data-charges/how-can-i-get-help-by-texting-150-on-pay-as-you-go-or-flex\nExodus & Pithus reports:\nhttps://reports.exodus-privacy.eu.org/fr/reports/uk.co.ee.myee/latest/\nhttps://beta.pithus.org/report/6e8de7e02aba34c4f02dc966b39002f60b0852f55da923cdccc4ba4c09ed4a4a\n",
+    "description": "Myee app (https://play.google.com/store/apps/details?id=uk.co.ee.myee)\nLets you control your EE pay monthly, pay as you go and WiFi devices. Check your data, bills, packs and more, and keep an eye on your spending.\nContains unnecessary analytics and most of the things the app does can be done by texting 150 from your mobile.\nSee https://ee.co.uk/help/help-new/billing-usage-and-top-up/call-text-and-data-charges/how-can-i-get-help-by-texting-150-on-pay-as-you-go-or-flex\nExodus & Pithus reports:\nhttps://reports.exodus-privacy.eu.org/fr/reports/uk.co.ee.myee/latest/\nhttps://beta.pithus.org/report/6e8de7e02aba34c4f02dc966b39002f60b0852f55da923cdccc4ba4c09ed4a4a",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18839,7 +19316,7 @@
   {
     "id": "android",
     "list": "Aosp",
-    "description": "Android UI ressource library. Provide all the elements of the User Interface. DO NOT REMOVE THIS!",
+    "description": "Android System\nAndroid system framework? Apk file name: framework-res\nCould be THE core of the android system.\nProbably very unsafe to disable.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18857,7 +19334,7 @@
   {
     "id": "com.agui.game",
     "list": "Oem",
-    "description": "Game (From Unihertz Jelly2)\n Removes distractions when selected apps are in use",
+    "description": "Game (From Unihertz Jelly2)\nRemoves distractions when selected apps are in use.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18866,7 +19343,7 @@
   {
     "id": "com.agui.studentmodel",
     "list": "Oem",
-    "description": "Student mode (From Unihertz Jelly2)\nSets limits to time - range, network, application limits and so on, to use a mobile/nphone reasonably. Under this mode, user is not allowed to install applications and/nrestore to factory settings. Applications not in white list are disabled.",
+    "description": "Student mode (From Unihertz Jelly2)\nSets limits to time - range, network, application limits and so on, to use a mobile phone reasonably. Under this mode, user is not allowed to install applications or factory reset. Applications not in white-list are disabled.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18906,12 +19383,12 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.mi.globalbrowser",
     "list": "Oem",
-    "description": "Mi Browser\nPrivacy nightmare. You really should use something else.\nFYI https://www.xda-developers.com/xiaomi-mi-web-browser-pro-mint-collecting-browsing-data-incognito-mode/\n\nNote: Since MIUI 12, you can no longer uninstall this app. Disabling it still works fine.",
+    "description": "Mi Browser\nPrivacy nightmare. You really should use something else.\nhttps://www.xda-developers.com/xiaomi-mi-web-browser-pro-mint-collecting-browsing-data-incognito-mode/\n\nNote: Since MIUI 12, you can no longer uninstall this app. Disabling it still works fine.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -18925,14 +19402,34 @@
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
-   },
-   {
-     "id": "com.tblenovo.lenovotips",
-     "list": "Oem",
-     "description": "Useless Lenovo Tips app used by Lenovo to display un-dismissable and un-mutable ads in notifications\nSource: https://news.ycombinator.com/item?id=28382081",
-     "dependencies": null,
-     "neededBy": null,
-     "labels": null,
-     "removal": "Recommended"
-    }
+  },
+  {
+    "id": "com.tblenovo.lenovotips",
+    "list": "Oem",
+    "description": "Useless Lenovo Tips app used by Lenovo to display un-dismissable and un-mutable ads in notifications.\nhttps://news.ycombinator.com/item?id=28382081",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.dolby.daxservice",
+    "list": "Misc",
+    "description": "Dolby\nRuns in the background as part of the system. Runs even if disabled.\n\"Optimizes system audio performance\" or something like that. This is likely the backend audio service, possibly applying settings from com.oneplus.sound.tuner (\"Dolby Atmos\") to the audio processing.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.oneplus.sound.tuner",
+    "list": "Oem",
+    "description": "Dolby Atmos\nRuns in the background as part of the system. Runs even if disabled.\nSound tuning for Atmos. Breaks the Dolby Atmos sound settings menu if disabled.\nCould in theory increase loudspeaker fidelity as it can be pre-calculated and stored as a corrective EQ curve, something not possible for headphones (they'd need a unique preset for each pair of headphones).",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  }
 ]
+
+


### PR DESCRIPTION
Added a bunch of packages from Oneplus 3/3T and Oneplus 9.
Added a bunch of descriptions for packages already in the list.
Corrected some erroneous descriptions.
Shortened some descriptions and corrected some grammar.
Changed "Removal" and "List" for some packages.


To save you some time and give a taste of my changes, here's some highlights from the list (all of these lacked descriptions or were very wrong):

**com.android.carrierdefaultapp**
> This package is a generic solution that allows carriers to indicate when a device has run OOB(Out Of Balance). Android devices that are OOB need carrier mitigation protocols to allow select data through(like to notify users their data/balance is out, or allow them to buy more data through the carrier app).
Will probably break that functionality if disabled, but is otherwise safe to disable(should only affect users that are out of data/balance?).
https://source.android.com/devices/tech/connect/oob-users

**com.android.ons - Opportunistic Network Service**
> From what I can glean in the source code it seems like this provides a list of available networks and assigns each network a priority.
I've never seen it run on its own, so this might be part of some automatic network switching setting that I have turned off.
https://cs.android.com/android/platform/superproject/+/master:packages/services/AlternativeNetworkAccess/src/com/android/ons/OpportunisticNetworkService.java
https://developer.android.com/reference/android/telephony/AvailableNetworkInfo
https://cs.android.com/android/platform/superproject/+/master:frameworks/base/telephony/java/android/telephony/AvailableNetworkInfo.java

**com.oneplus.orm**
> Seems to be Oneplus' Memory Management System according to a press-kit/-release they made for Android 11 (multiple sites wrote "ORM Memory Management System" word-for-word).
Runs in the background as part of the system. Runs even if disabled? Doesn't use any RAM when disabled tho, vs ~50MB when enabled.
Seems safe to disable, haven't noticed any negative effects in weeks of use, but I assume it breaks the "RAM Boost" feature (which is pointless anyway IMO).
Apk file name: OPOmm, mm = Memory Management?

**com.oneplus.screenrecord - Screen Recorder**
> The Android 11 screen recorder with some Oneplus modifications.
Runs the \"SystemUITileService\" when you have it as one of the quicksettings tiles, but doesn't seem to run in the background outside of that.
Doesn't have an app icon, but you can create a shortcut to it with the Activity Launcher app.
https://f-droid.org/en/packages/de.szalkowski.activitylauncher/

**com.qualcomm.qti.smq - QTR (Qualcomm Technology Reporting)**
> Runs on boot.
Seems like a telemetry package, supposedly sending hardware & software type, configuration and performance data.
Contains a "QtiFeedbackActivity" called "Hardware Feedback". When that hidden activity is launched through Activity Launcher you get a screen showing just a checkbox and this text:
"Collecting hardware and software type, configuration, and performance data helps Qualcomm improve next generation device battery life, security, and performance. Untick to disable."
Unticking isn't remembered; it's ticked again next time you enter. There's also a "Learn More" link that leads to: http://reporting.qti.qualcomm.com/learnmore_en.html which doesn't load for me.


<details>
<summary>Image of activity (obviously can't be included in the list, but figured I'd show it here on Github):</summary>

![QTR hidden activity - Cropped](https://user-images.githubusercontent.com/24507868/152659098-eb4e9079-bd3e-4b77-802c-887be4024f23.jpg)

</details>

**net.oneplus.launcher - Oneplus Launcher**
> Runs in the background as part of the system.
Aside from obviously handling the default launcher itself, it also handles the Recents UI on Android 9, the home&recents gestures in Android 11, some submenus in the Settings app and possibly more that I'm unaware of.
Probably not a good idea to disable.

**com.google.android.apps.work.oobconfig - Device Setup**
> Sets up device to be managed by EMM (Enterprise Mobility Management), which "allows organizations to securely enable employee use of mobile devices".
Might also be what does the actual management on your device, if you set it up as a work device.
Only seems to run on boot(not in the background after boot) if you haven't set up your device as a work device.
I tried to disable it through UAD, but nothing happens? Seems immune to disabling?
https://bayton.org/2020/11/google-announce-big-changes-to-zero-touch/
https://bayton.org/docs/enterprise-mobility/android/what-is-android-zero-touch-enrolment/


com.qualcomm.qti.smq nicely illustrates how useful [Activity Launcher](https://f-droid.org/en/packages/de.szalkowski.activitylauncher/) can be in combination with [a Package Viewer that shows Activities](https://play.google.com/store/apps/details?id=cz.seeq.prog.android.packageviewer).


As you saw in one of the new list entries; I've found a way to see running system processes. The [Simple System Monitor](https://play.google.com/store/apps/details?id=com.dp.sysmonitor.app) app with the PACKAGE_USAGE_STATS permission (granted through ADB) is the only way I've found in Android 11.
Seeing running system processes also showed some interesting things, like some processes running even while disabled(I assume Uninstall would yield the same result). For example com.qualcomm.location and Dolby & Dirac Sound System services run even if disabled, **with RAM usage**. I guess some system packages(com.oneplus.orm) rely on access to user-space(which disable/uninstall removes) while others(qualcomm.location/audio systems) don't and run just like normal even when disabled/uninstalled?


My changes have been over the course of a couple of weeks, but I've taken care to include any changes in recent commits, so nothing should be lost and it should merge nicely with the main branch.