### PR TITLE
[Package] Mark Gmail as recommended to remove

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17115,7 +17115,7 @@
     "dependencies": null,
     "neededBy": null,
     "labels": null,
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   {
     "id": "com.google.android.ims",


### PR DESCRIPTION
Gmail is not needed for anything but e-mails which can also be done using a different app or any web browser on the smartphone or any other device.