### PR TITLE
[Packages] Improve description for Google Keyboard

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17147,7 +17147,7 @@
   {
     "id": "com.google.android.inputmethod.latin",
     "list": "Google",
-    "description": "Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\n",
+    "description": "Gboard – the Google Keyboard (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)\n",
     "dependencies": null,
     "neededBy": null,
     "labels": null,


### PR DESCRIPTION
Google Keyboard is listed as "Gboard" on my Android 12 phone and on play store website, so it should have the same title as on play store here.