### PR TITLE
pkg: update `com.google.android.apps.messaging`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16886,7 +16886,7 @@
   {
     "id": "com.google.android.apps.messaging",
     "list": "Google",
-  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.\nRemoving this may cause issues with receiving verification text messages and calls.",
+  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.\nWARNING: Removing this may cause issues with receiving verification text messages and calls. Please let us know your experience with this on https://github.com/0x192/universal-android-debloater/pull/250 (give your phone model + Android version)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16886,7 +16886,7 @@
   {
     "id": "com.google.android.apps.messaging",
     "list": "Google",
-  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.",
+  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.\nRemoving this may cause issues with receiving verification text messages and calls.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16886,7 +16886,7 @@
   {
     "id": "com.google.android.apps.messaging",
     "list": "Google",
-  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.\nWARNING: Removing this may cause issues with receiving verification text messages and calls. Please let us know your experience with this on https://github.com/0x192/universal-android-debloater/pull/250 (give your phone model + Android version)",
+  "description": "Google Messages (SMS+RCS) (https://play.google.com/store/apps/details?id=com.google.android.apps.messaging)\nRuns in the background.\nQKSMS is a good FOSS replacement.\nWARNING: Removing this may cause issues with receiving 2FA verification text messages and calls from Google on some devices. Please let us know your experience with this on https://github.com/0x192/universal-android-debloater/pull/250 (give your phone model + Android version)",
     "dependencies": null,
     "neededBy": null,
     "labels": null,


### PR DESCRIPTION
**Your phone**: Xiaomi 11T

**Packages documentation to update:**
```
com.google.android.apps.messaging
```
## Documentation chage
**Current description**
```
Google Messages (SMS+RCS) https://play.google.com/store/apps/details?id=com.google.android.appls.messaging)
Runs in the background.
QKSMS is a good FOSS replacement.
```

**Proposed description**
```
Google Messages (SMS+RCS) https://play.google.com/store/apps/details?id=com.google.android.appls.messaging)
Runs in the background.
QKSMS is a good FOSS replacement.
Removing this may cause issues with receiving verification text messages and calls.
```

## Notes
Further investigation is probably needed, but until I have reenabled this, I was unable to get any calls or texts from Google verification (2FA). Just having this reenabled (while using my FOSS texting app) instantly fixed this issue.