### PR TITLE
refactor: major code overhaul + support for the new Iced theme API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24606928a235e73cdef55a0c909719cadd72fce573e5713d58cb2952d8f5794c"
+checksum = "846ffacb9d0c8b879ef9e565b59e18fb76d6a61013e5bd24ecc659864e6b1a1f"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -23,6 +23,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
@@ -45,16 +51,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_glue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
-
-[[package]]
 name = "android_system_properties"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20ae67ce26261f218e2b3f2f0d01887a9818283ca6fb260fa7c67e253d61c92"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
 dependencies = [
  "libc",
 ]
@@ -67,6 +67,18 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -108,9 +120,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -135,24 +147,24 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "bytemuck"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -167,12 +179,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calloop"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
+checksum = "a22a6a8f622f797120d452c630b0ab12e1331a1a753e2039ce7868d4ac77b4ee"
 dependencies = [
  "log",
- "nix 0.22.3",
+ "nix 0.24.2",
+ "slotmap",
+ "thiserror",
+ "vec_map",
 ]
 
 [[package]]
@@ -180,12 +195,6 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -210,14 +219,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -229,9 +240,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clipboard-win"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
+checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
 dependencies = [
  "error-code",
  "str-buf",
@@ -269,6 +280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,9 +297,9 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.3",
- "core-graphics 0.22.3",
- "foreign-types",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -292,9 +312,9 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.3",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -328,29 +348,13 @@ checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -360,26 +364,14 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
-dependencies = [
- "bitflags",
- "core-foundation 0.7.0",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.3",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -390,22 +382,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.3",
- "foreign-types",
+ "core-foundation",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
 [[package]]
-name = "core-video-sys"
-version = "0.1.4"
+name = "core-text"
+version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
 dependencies = [
- "cfg-if 0.1.10",
- "core-foundation-sys 0.7.0",
- "core-graphics 0.19.2",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
- "objc",
 ]
 
 [[package]]
@@ -414,38 +405,38 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -454,12 +445,35 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "crossfont"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66b1c1979c4362323f03ab6bf7fb522902bfc418e0c37319ab347f9561d980f"
+dependencies = [
+ "cocoa",
+ "core-foundation",
+ "core-foundation-sys",
+ "core-graphics",
+ "core-text",
+ "dwrote",
+ "foreign-types 0.5.0",
+ "freetype-rs",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "pkg-config",
+ "servo-fontconfig",
+ "winapi",
 ]
 
 [[package]]
@@ -515,6 +529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,10 +579,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "either"
-version = "1.7.0"
+name = "dwrote"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "error-code"
@@ -581,6 +618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
+
+[[package]]
 name = "fern"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,10 +643,19 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys",
+]
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -624,7 +680,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -632,6 +709,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -644,10 +727,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.21"
+name = "freetype-rs"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
+dependencies = [
+ "bitflags",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -660,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -670,15 +775,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -688,15 +793,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -705,21 +810,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -758,7 +863,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -809,24 +914,23 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.28.0"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
+version = "0.29.1"
+source = "git+https://github.com/iced-rs/glutin?rev=da8d291486b4c9bec12487a46c119c4b1d386abf#da8d291486b4c9bec12487a46c119c4b1d386abf"
 dependencies = [
- "android_glue",
  "cgl",
  "cocoa",
- "core-foundation 0.9.3",
+ "core-foundation",
  "glutin_egl_sys",
- "glutin_emscripten_sys",
  "glutin_gles2_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "lazy_static",
  "libloading",
  "log",
  "objc",
+ "once_cell",
  "osmesa-sys",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
+ "raw-window-handle 0.5.0",
  "wayland-client",
  "wayland-egl",
  "winapi",
@@ -835,22 +939,17 @@ dependencies = [
 
 [[package]]
 name = "glutin_egl_sys"
-version = "0.1.5"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
+version = "0.1.6"
+source = "git+https://github.com/iced-rs/glutin?rev=da8d291486b4c9bec12487a46c119c4b1d386abf#da8d291486b4c9bec12487a46c119c4b1d386abf"
 dependencies = [
  "gl_generator",
  "winapi",
 ]
 
 [[package]]
-name = "glutin_emscripten_sys"
-version = "0.1.1"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
-
-[[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
+source = "git+https://github.com/iced-rs/glutin?rev=da8d291486b4c9bec12487a46c119c4b1d386abf#da8d291486b4c9bec12487a46c119c4b1d386abf"
 dependencies = [
  "gl_generator",
  "objc",
@@ -858,8 +957,8 @@ dependencies = [
 
 [[package]]
 name = "glutin_glx_sys"
-version = "0.1.7"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
+version = "0.1.8"
+source = "git+https://github.com/iced-rs/glutin?rev=da8d291486b4c9bec12487a46c119c4b1d386abf#da8d291486b4c9bec12487a46c119c4b1d386abf"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -868,16 +967,16 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
-source = "git+https://github.com/iced-rs/glutin?rev=7a0ee02782eb2bf059095e0c953c4bb53f1eef0e#7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
+source = "git+https://github.com/iced-rs/glutin?rev=da8d291486b4c9bec12487a46c119c4b1d386abf#da8d291486b4c9bec12487a46c119c4b1d386abf"
 dependencies = [
  "gl_generator",
 ]
 
 [[package]]
 name = "glyph_brush"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c65dd1f1fbb6209aa00f78636e436ad0a55b7d8e5de886d00720dcad9c6e2"
+checksum = "ac02497410cdb5062cc056a33f2e1e19ff69fbf26a4be9a02bf29d6e17ea105b"
 dependencies = [
  "glyph_brush_draw_cache",
  "glyph_brush_layout",
@@ -933,13 +1032,13 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
+checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -963,18 +1062,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "hermit-abi"
@@ -992,9 +1085,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "iced"
 version = "0.4.2"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1002,7 +1108,6 @@ dependencies = [
  "iced_glutin",
  "iced_graphics",
  "iced_native",
- "iced_pure",
  "iced_wgpu",
  "iced_winit",
  "thiserror",
@@ -1011,16 +1116,17 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.5.0"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "bitflags",
+ "palette",
  "wasm-timer",
 ]
 
 [[package]]
 name = "iced_futures"
 version = "0.4.1"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "futures",
  "log",
@@ -1031,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.3.0"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1046,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "iced_glutin"
 version = "0.3.0"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "glutin",
  "iced_graphics",
@@ -1058,12 +1164,11 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.3.1"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "bytemuck",
  "glam",
  "iced_native",
- "iced_pure",
  "iced_style",
  "raw-window-handle 0.4.3",
  "thiserror",
@@ -1072,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.5.1"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1083,27 +1188,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_pure"
-version = "0.2.2"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
-dependencies = [
- "iced_native",
- "iced_style",
- "num-traits",
-]
-
-[[package]]
 name = "iced_style"
 version = "0.4.0"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "iced_core",
+ "lazy_static",
+ "palette",
 ]
 
 [[package]]
 name = "iced_wgpu"
 version = "0.5.1"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1122,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.4.0"
-source = "git+https://github.com/hecrj/iced.git#66eb6263003c1bbedd1fd14d6b12f172d20a6211"
+source = "git+https://github.com/0x192/iced.git?branch=patch/theme#0da7a3491588dcddf6cbf19630bdbf348650a4f0"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -1159,14 +1256,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown",
 ]
 
 [[package]]
 name = "inplace_it"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90953f308a79fe6d62a4643e51f848fbfddcd05975a38e69fdf4ab86a7baf7ca"
+checksum = "67f0347836f3f6362c1e7efdadde2b1c4b4556d211310b70631bae7eb692070b"
 
 [[package]]
 name = "instant"
@@ -1174,7 +1271,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1182,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jni-sys"
@@ -1194,9 +1291,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1235,9 +1332,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -1245,7 +1342,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -1257,9 +1354,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1271,7 +1368,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1297,18 +1394,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.3.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -1331,7 +1419,7 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "log",
  "objc",
 ]
@@ -1391,14 +1479,15 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
+checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle 0.5.0",
  "thiserror",
 ]
 
@@ -1410,17 +1499,18 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
+checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-macro",
  "ndk-sys",
+ "once_cell",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1438,9 +1528,12 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "nix"
@@ -1450,20 +1543,21 @@ checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
 
 [[package]]
 name = "nix"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1567,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "ordered-float"
@@ -1591,11 +1685,35 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1e509cfe7a12db2a90bfa057dfcdbc55a347f5da677c506b53dd099cfec9d"
+checksum = "07ef1a404ae479dd6906f4fa2c88b3c94028f1284beb42a47c183a7c27ee9a3e"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "palette"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
+dependencies = [
+ "approx",
+ "num-traits",
+ "palette_derive",
+ "phf",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05eedf46a8e7c27f74af0c9cfcdb004ceca158cb1b918c6f68f8d7a549b3e427"
+dependencies = [
+ "find-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1625,7 +1743,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -1639,7 +1757,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1651,6 +1769,48 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1671,6 +1831,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "png"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,19 +1850,20 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -1703,9 +1876,9 @@ checksum = "2f61dcf0b917cd75d4521d7343d1ffff3d1583054133c9b5cbea3375c703c40d"
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1766,6 +1939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
+dependencies = [
+ "cty",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1811,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1822,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "renderdoc-sys"
@@ -1876,9 +2058,18 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safe_arch"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1903,19 +2094,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.138"
+name = "sctk-adwaita"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "04b7c47a572f73de28bee5b5060d085b42b6ce1e4ee2b49c956ea7b25e94b6f0"
+dependencies = [
+ "crossfont",
+ "log",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1924,13 +2127,34 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1944,10 +2168,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.6"
+name = "siphasher"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"
@@ -1966,35 +2199,17 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
+checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
  "bitflags",
  "calloop",
  "dlib",
  "lazy_static",
  "log",
- "memmap2 0.3.1",
- "nix 0.22.3",
- "pkg-config",
- "wayland-client",
- "wayland-cursor",
- "wayland-protocols",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
-dependencies = [
- "bitflags",
- "dlib",
- "lazy_static",
- "log",
- "memmap2 0.5.4",
- "nix 0.24.1",
+ "memmap2",
+ "nix 0.24.2",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -2007,7 +2222,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8"
 dependencies = [
- "smithay-client-toolkit 0.16.0",
+ "smithay-client-toolkit",
  "wayland-client",
 ]
 
@@ -2035,9 +2250,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "static_init"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208e44bfab7faad5dee24112ea8af2f76aa0d501ea3370b5d4b81729a528f119"
+checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -2081,9 +2296,9 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2112,18 +2327,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2139,6 +2354,31 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "bytemuck",
+ "cfg-if",
+ "png",
+ "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
 ]
 
 [[package]]
@@ -2177,7 +2417,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rand",
  "static_assertions",
 ]
@@ -2210,9 +2450,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -2249,9 +2489,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
  "base64",
  "chunked_transfer",
@@ -2279,6 +2519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,23 +2544,23 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2323,11 +2569,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2335,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2345,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2358,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-timer"
@@ -2379,14 +2625,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91223460e73257f697d9e23d401279123d36039a3f7a449e983f123292d4458f"
+checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix 0.22.3",
+ "nix 0.24.2",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -2395,11 +2641,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-commons"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6e5e340d7c13490eca867898c4cec5af56c27a5ffe5c80c6fc4708e22d33e"
+checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix 0.22.3",
+ "nix 0.24.2",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -2407,20 +2653,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52758f13d5e7861fc83d942d3d99bf270c83269575e52ac29e5b73cb956a6bd"
+checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
- "nix 0.22.3",
+ "nix 0.24.2",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-egl"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83281d69ee162b59031c666385e93bde4039ec553b90c4191cdb128ceea29a3a"
+checksum = "402de949f81a012926d821a2d659f930694257e76dd92b6e0042ceb27be4107d"
 dependencies = [
  "wayland-client",
  "wayland-sys",
@@ -2428,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60147ae23303402e41fe034f74fb2c35ad0780ee88a1c40ac09a3be1e7465741"
+checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
  "bitflags",
  "wayland-client",
@@ -2440,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a1ed3143f7a143187156a2ab52742e89dac33245ba505c17224df48939f9e0"
+checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9341df79a8975679188e37dab3889bfa57c44ac2cb6da166f519a81cbe452d4"
+checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
  "lazy_static",
@@ -2462,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2482,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
 ]
@@ -2495,7 +2741,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277e967bf8b7820a76852645a6bce8bbd31c32fda2042e82d8e3ea75fda8892d"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "js-sys",
  "log",
  "naga",
@@ -2512,11 +2758,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266ca6be6004fd1b2a768023b1cb0afbf7af0cbffaba19af25c5792d44e74784"
+checksum = "89b92788dec9d0c1bed849a1b83f01b2ee12819bf04a79c90f68e4173f7b5ba2"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "bit-vec",
  "bitflags",
  "cfg_aliases",
@@ -2537,19 +2783,19 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef50e48812c7eb958fa52d28a912f8b77c96453ebab21c72b01cdda61d3e65d"
+checksum = "20cbdfc3d0637dba3d5536b93adef3d26023a0b96f0e1ee5ee9560a401d9f646"
 dependencies = [
  "android_system_properties",
- "arrayvec",
+ "arrayvec 0.7.2",
  "ash",
  "bit-set",
  "bitflags",
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
+ "foreign-types 0.3.2",
  "fxhash",
  "glow",
  "gpu-alloc",
@@ -2576,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48d691b733b9d50ea8cb18f377fd1ed927c90c55ad1ec5b90f68885471977f7"
+checksum = "1f762cbc08e1a51389859cf9c199c7aef544789cf3510889aab12c607f701604"
 dependencies = [
  "bitflags",
 ]
@@ -2694,41 +2940,50 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winit"
-version = "0.26.0"
-source = "git+https://github.com/iced-rs/winit?rev=02a12380960cec2f351c09a33d6a7cc2789d96a6#02a12380960cec2f351c09a33d6a7cc2789d96a6"
+version = "0.27.2"
+source = "git+https://github.com/iced-rs/winit.git?rev=940457522e9fb9f5dac228b0ecfafe0138b4048c#940457522e9fb9f5dac228b0ecfafe0138b4048c"
 dependencies = [
  "bitflags",
  "cocoa",
- "core-foundation 0.9.3",
- "core-graphics 0.22.3",
- "core-video-sys",
+ "core-foundation",
+ "core-graphics",
  "dispatch",
  "instant",
- "lazy_static",
  "libc",
  "log",
  "mio",
  "ndk",
  "ndk-glue",
- "ndk-sys",
  "objc",
- "parking_lot 0.11.2",
+ "once_cell",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "raw-window-handle 0.4.3",
- "smithay-client-toolkit 0.15.4",
+ "raw-window-handle 0.5.0",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",
  "wayland-protocols",
  "web-sys",
- "winapi",
+ "windows-sys",
  "x11-dl",
 ]
 
 [[package]]
-name = "x11-dl"
-version = "2.19.1"
+name = "wio"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ self-update = ["flate2", "tar"]
 no-self-update = []
 
 [dependencies]
-iced = { git = "https://github.com/hecrj/iced.git", features = ["pure"] }
+iced = { git = "https://github.com/0x192/iced.git", branch = "patch/theme" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 static_init = "^1.0"

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -90,7 +90,7 @@ pub fn adb_shell_command(shell: bool, args: &str) -> Result<String, String> {
     }
 }
 
-pub fn list_all_system_packages(user_id: &Option<&User>) -> String {
+pub fn list_all_system_packages(user_id: Option<&User>) -> String {
     let action = match user_id {
         Some(user_id) => format!("pm list packages -s -u --user {}", user_id.id),
         None => "pm list packages -s -u".to_string(),
@@ -101,7 +101,7 @@ pub fn list_all_system_packages(user_id: &Option<&User>) -> String {
         .replace("package:", "")
 }
 
-pub fn hashset_system_packages(state: PackageState, user_id: &Option<&User>) -> HashSet<String> {
+pub fn hashset_system_packages(state: PackageState, user_id: Option<&User>) -> HashSet<String> {
     let user = match user_id {
         Some(user_id) => format!(" --user {}", user_id.id),
         None => "".to_string(),
@@ -137,10 +137,10 @@ pub fn action_handler(
             };
 
             match phone.android_sdk {
-                i if i >= 23 => commands,                // > Android Lollipop (6.0)
+                sdk if sdk >= 23 => commands,            // > Android Lollipop (6.0)
                 21 | 22 => vec!["pm hide", "pm clear"],  // Android Lollipop (5.x)
                 19 | 20 => vec!["pm block", "pm clear"], // Android KitKat (4.4/4.4W)
-                _ => vec!["pm uninstall"], // Disable mode is unavailable on older devices because the needed ADB commands need root
+                _ => vec!["pm uninstall"], // Disable mode is unavailable on older devices because the specific ADB commands need root
             }
         }
         PackageState::Uninstalled => {
@@ -217,7 +217,7 @@ pub fn get_user_list() -> Vec<User> {
 }
 
 // getprop ro.serialno
-pub async fn get_device_list() -> Vec<Phone> {
+pub async fn get_devices_list() -> Vec<Phone> {
     match retry(
         Fixed::from_millis(500).take(120),
         || match adb_shell_command(false, "devices") {

--- a/src/core/theme.rs
+++ b/src/core/theme.rs
@@ -7,6 +7,12 @@ pub struct Theme {
     pub palette: ColorPalette,
 }
 
+impl Default for Theme {
+    fn default() -> Self {
+        Theme::lupin()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct BaseColors {
     pub background: Color,

--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -197,7 +197,7 @@ impl std::fmt::Display for Removal {
     }
 }
 
-pub async fn load_debloat_lists(remote: bool) -> (Result<HashMap<String, Package>, ()>, bool) {
+pub fn load_debloat_lists(remote: bool) -> (Result<HashMap<String, Package>, ()>, bool) {
     let cached_uad_lists: PathBuf = CACHE_DIR.join("uad_lists.json");
     let mut error = false;
     let list: Vec<Package> = if remote {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -5,10 +5,8 @@ use crate::core::theme::Theme;
 use crate::core::uad_lists::{Package, PackageState, Removal, UadList};
 use crate::gui::views::list::Selection;
 use crate::gui::widgets::package_row::PackageRow;
-use crate::gui::ICONS;
 use chrono::offset::Utc;
 use chrono::DateTime;
-use iced::{alignment, Length, Text};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, prelude::*, BufReader};
@@ -17,7 +15,7 @@ use std::process::Command;
 
 pub fn fetch_packages(
     uad_lists: &HashMap<String, Package>,
-    user_id: &Option<&User>,
+    user_id: Option<&User>,
 ) -> Vec<PackageRow> {
     let all_system_packages = list_all_system_packages(user_id); // installed and uninstalled packages
     let enabled_system_packages = hashset_system_packages(PackageState::Enabled, user_id);
@@ -120,14 +118,6 @@ pub fn import_selection(packages: &mut [PackageRow], selection: &mut Selection) 
     }
 
     Ok(())
-}
-
-pub fn icon(unicode: char) -> Text {
-    Text::new(&unicode.to_string())
-        .font(ICONS)
-        .width(Length::Units(17))
-        .horizontal_alignment(alignment::Horizontal::Center)
-        .size(17)
 }
 
 pub fn string_to_theme(theme: String) -> Theme {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,60 +2,47 @@ pub mod style;
 pub mod views;
 pub mod widgets;
 
-pub use crate::core::sync::{get_device_list, Phone};
-pub use crate::core::uad_lists::Package;
-use crate::core::uad_lists::{load_debloat_lists, UadListState};
-use crate::core::update::{get_latest_release, SelfUpdateState, SelfUpdateStatus};
-use crate::core::utils::{icon, perform_commands};
-use iced::pure::widget::Text;
-use iced::pure::{button, column, container, pick_list, row, text, Pure, State};
-use iced::{
-    window::Settings as Window, Alignment, Application, Command, Element, Font, Length, Settings,
-    Space,
-};
+use crate::core::sync::{get_devices_list, Phone};
+use crate::core::theme::Theme;
+use crate::core::uad_lists::UadListState;
+use crate::core::update::{get_latest_release, Release, SelfUpdateState, SelfUpdateStatus};
+use crate::core::utils::perform_commands;
 
-use std::collections::HashMap;
-use std::env;
-use std::path::PathBuf;
-pub use views::about::{About as AboutView, Message as AboutMessage};
-pub use views::list::{
-    List as AppsView, LoadingState as ListLoadingState, Message as AppsMessage, State as ListState,
-};
-pub use views::settings::{
-    Message as SettingsMessage, Phone as SettingsPhone, Settings as SettingsView,
-};
+use views::about::{About as AboutView, Message as AboutMessage};
+use views::list::{List as AppsView, LoadingState as ListLoadingState, Message as AppsMessage};
+use views::settings::{Message as SettingsMessage, Settings as SettingsView};
+use widgets::navigation_menu::nav_menu;
 
-pub const ICONS: Font = Font::External {
-    name: "Icons",
-    bytes: include_bytes!("../../resources/assets/icons.ttf"),
-};
+use iced::widget::column;
+use iced::{window::Settings as Window, Application, Command, Element, Length, Renderer, Settings};
+use std::{env, path::PathBuf};
 
 #[cfg(feature = "self-update")]
 use crate::core::update::{bin_name, download_update_to_temp_file, remove_file};
 
-#[derive(Debug, Clone)]
-pub enum View {
+#[derive(Default, Debug, Clone)]
+enum View {
+    #[default]
     List,
     About,
     Settings,
 }
 
-impl Default for View {
-    fn default() -> Self {
-        Self::List
-    }
+#[derive(Default, Clone)]
+pub struct UpdateState {
+    self_update: SelfUpdateState,
+    uad_list: UadListState,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct UadGui {
-    ready: bool,
     view: View,
-    state: State,
     apps_view: AppsView,
     about_view: AboutView,
     settings_view: SettingsView,
-    device_list: Vec<Phone>,
-    selected_device: Option<Phone>,
+    devices_list: Vec<Phone>,
+    selected_device: Option<Phone>, // index of devices_list
+    update_state: UpdateState,
 }
 
 #[derive(Debug, Clone)]
@@ -70,14 +57,14 @@ pub enum Message {
     SettingsAction(SettingsMessage),
     RefreshButtonPressed,
     RebootButtonPressed,
-    UadListsDownloaded((Result<HashMap<String, Package>, ()>, bool)),
-    InitList,
-    InitDevice(Vec<Phone>),
+    LoadDevices(Vec<Phone>),
     _NewReleaseDownloaded(Result<(PathBuf, PathBuf), ()>),
+    GetLatestRelease(Result<Option<Release>, ()>),
     Nothing,
 }
 
 impl Application for UadGui {
+    type Theme = Theme;
     type Executor = iced::executor::Default;
     type Message = Message;
     type Flags = ();
@@ -86,102 +73,37 @@ impl Application for UadGui {
         (
             Self::default(),
             Command::batch([
-                Command::perform(Self::download_uad_list(), |_| Message::InitList),
-                Command::perform(get_device_list(), Message::InitDevice),
-                Command::perform(Self::send_self_update_message(), Message::SettingsAction),
+                Command::perform(get_devices_list(), Message::LoadDevices),
+                Command::perform(
+                    async move { get_latest_release() },
+                    Message::GetLatestRelease,
+                ),
             ]),
         )
+    }
+
+    fn theme(&self) -> Theme {
+        self.settings_view.theme.clone()
     }
 
     fn title(&self) -> String {
         String::from("Universal Android Debloater")
     }
-    fn update(&mut self, message: Message) -> Command<Message> {
-        match message {
-            Message::InitList => {
-                warn!("Trying to download remote UAD list");
-                self.apps_view.state = ListState::Loading(ListLoadingState::DownloadingList);
-                Command::perform(load_debloat_lists(true), Message::UadListsDownloaded)
-            }
-            Message::UadListsDownloaded((uad_lists, _)) => match uad_lists {
-                Ok(list) => {
-                    if !list.is_empty() {
-                        self.apps_view.uad_lists = list;
+    fn update(&mut self, msg: Message) -> Command<Message> {
+        match msg {
+            Message::LoadDevices(devices_list) => {
+                self.selected_device = match &self.selected_device {
+                    Some(s_device) => {
+                        // Try to reload last selected phone
+                        devices_list
+                            .iter()
+                            .find(|phone| phone.adb_id == s_device.adb_id)
+                            .map(|x| x.to_owned())
                     }
-                    self.settings_view.list_update_state = UadListState::Done;
-
-                    if self.ready {
-                        Command::perform(
-                            Self::load_phone_packages(
-                                self.selected_device.clone().unwrap_or_default(),
-                            ),
-                            Message::AppsAction,
-                        )
-                    } else {
-                        self.ready = true;
-                        self.apps_view.state = ListState::Loading(ListLoadingState::FindingPhones);
-                        Command::none()
-                    }
-                }
-                Err(_) => {
-                    self.settings_view.list_update_state = UadListState::Failed;
-                    if let ListState::Ready = self.apps_view.state {
-                    } else {
-                        self.apps_view.state =
-                            ListState::Loading(ListLoadingState::DownloadingList);
-                    }
-                    Command::none()
-                }
-            },
-            Message::InitDevice(device_list) => {
-                self.device_list = device_list;
-                self.settings_view.phone = SettingsPhone::default();
-
-                // Save the current selected device
-                let i = self
-                    .device_list
-                    .iter()
-                    .position(|phone| *phone == self.selected_device.clone().unwrap_or_default())
-                    .unwrap_or(0);
-
-                // Try to reload last selected phone
-                if !self.device_list.is_empty() {
-                    self.selected_device = match i < self.device_list.len() {
-                        true => Some(self.device_list[i].clone()),
-                        false => match self.device_list.last() {
-                            Some(last) => Some(last.clone()),
-                            None => Some(Phone::default()),
-                        },
-                    };
-                    self.view = View::List;
-                } else {
-                    self.selected_device = None;
-                }
-                if self.settings_view.list_update_state != UadListState::Downloading || self.ready {
-                    Command::perform(
-                        Self::load_phone_packages(self.selected_device.clone().unwrap_or_default()),
-                        Message::AppsAction,
-                    )
-                } else {
-                    self.ready = true;
-                    Command::none()
-                }
-            }
-            Message::RefreshButtonPressed => {
-                self.apps_view.state = ListState::Loading(ListLoadingState::FindingPhones);
-                self.selected_device = None;
-                self.ready = true;
-                Command::perform(get_device_list(), Message::InitDevice)
-            }
-            Message::RebootButtonPressed => {
-                self.apps_view.state = ListState::Loading(ListLoadingState::FindingPhones);
-                self.selected_device = None;
-                self.device_list = vec![];
-                self.ready = false;
-                Command::perform(
-                    perform_commands("reboot".to_string(), 0, "ADB".to_string()),
-                    |_| Message::Nothing,
-                )
+                    None => devices_list.first().map(|x| x.to_owned()),
+                };
+                self.devices_list = devices_list;
+                self.update(Message::AppsAction(AppsMessage::LoadUadList(true)))
             }
             Message::AppsPress => {
                 self.view = View::List;
@@ -189,18 +111,35 @@ impl Application for UadGui {
             }
             Message::AboutPressed => {
                 self.view = View::About;
-                self.settings_view.self_update_state = SelfUpdateState::default();
-                Command::perform(Self::send_self_update_message(), Message::SettingsAction)
+                self.update_state.self_update = SelfUpdateState::default();
+                Command::perform(
+                    async move { get_latest_release() },
+                    Message::GetLatestRelease,
+                )
             }
             Message::SettingsPressed => {
                 self.view = View::Settings;
                 Command::none()
+            }
+            Message::RefreshButtonPressed => {
+                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                Command::perform(get_devices_list(), Message::LoadDevices)
+            }
+            Message::RebootButtonPressed => {
+                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                self.selected_device = None;
+                self.devices_list = vec![];
+                Command::perform(
+                    perform_commands("reboot".to_string(), 0, "ADB".to_string()),
+                    |_| Message::Nothing,
+                )
             }
             Message::AppsAction(msg) => self
                 .apps_view
                 .update(
                     &mut self.settings_view,
                     &mut self.selected_device.clone().unwrap_or_default(),
+                    &mut self.update_state.uad_list,
                     msg,
                 )
                 .map(Message::AppsAction),
@@ -214,25 +153,19 @@ impl Application for UadGui {
 
                 match msg {
                     AboutMessage::UpdateUadLists => {
-                        self.settings_view.list_update_state = UadListState::Downloading;
-                        Command::perform(Self::download_uad_list(), |_| Message::InitList)
+                        self.update_state.uad_list = UadListState::Downloading;
+                        self.apps_view.loading_state = ListLoadingState::DownloadingList;
+                        self.update(Message::AppsAction(AppsMessage::LoadUadList(true)))
                     }
                     AboutMessage::DoSelfUpdate => {
                         #[cfg(feature = "self-update")]
-                        if self
-                            .settings_view
-                            .self_update_state
-                            .latest_release
-                            .is_some()
-                        {
-                            self.settings_view.self_update_state.status =
-                                SelfUpdateStatus::Updating;
-                            self.apps_view.state =
-                                ListState::Loading(ListLoadingState::_UpdatingUad);
+                        if self.update_state.self_update.latest_release.is_some() {
+                            self.update_state.self_update.status = SelfUpdateStatus::Updating;
+                            self.apps_view.loading_state = ListLoadingState::_UpdatingUad;
                             let bin_name = bin_name().to_owned();
                             let release = self
-                                .settings_view
-                                .self_update_state
+                                .update_state
+                                .self_update
                                 .latest_release
                                 .as_ref()
                                 .unwrap()
@@ -250,13 +183,20 @@ impl Application for UadGui {
                     _ => Command::none(),
                 }
             }
-            Message::DeviceSelected(device) => {
-                self.selected_device = Some(device);
+            Message::DeviceSelected(s_device) => {
+                self.selected_device = Some(s_device.clone());
                 self.view = View::List;
-                Command::perform(
-                    Self::load_phone_packages(self.selected_device.clone().unwrap_or_default()),
-                    Message::AppsAction,
-                )
+                env::set_var("ANDROID_SERIAL", s_device.adb_id);
+                info!("{:-^65}", "-");
+                info!(
+                    "ANDROID_SDK: {} | PHONE: {}",
+                    s_device.android_sdk, s_device.model
+                );
+                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                self.update(Message::AppsAction(AppsMessage::LoadPhonePackages((
+                    self.apps_view.uad_lists.clone(),
+                    UadListState::Done,
+                ))))
             }
             Message::_NewReleaseDownloaded(_res) => {
                 debug!("UAD update has been download!");
@@ -303,137 +243,47 @@ impl Application for UadGui {
                 }
                 Command::none()
             }
-            Message::Nothing => Command::perform(get_device_list(), Message::InitDevice),
+            Message::GetLatestRelease(release) => {
+                match release {
+                    Ok(r) => {
+                        self.update_state.self_update.status = SelfUpdateStatus::Done;
+                        self.update_state.self_update.latest_release = r
+                    }
+                    Err(_) => self.update_state.self_update.status = SelfUpdateStatus::Failed,
+                };
+                Command::none()
+            }
+            _ => Command::none(),
         }
     }
 
-    fn view(&mut self) -> Element<Self::Message> {
-        let apps_refresh_btn = button(refresh_icon())
-            .on_press(Message::RefreshButtonPressed)
-            .padding(5)
-            .style(style::RefreshButton(self.settings_view.theme.palette));
-
-        let reboot_btn = button("Reboot")
-            .on_press(Message::RebootButtonPressed)
-            .padding(5)
-            .style(style::RefreshButton(self.settings_view.theme.palette));
-
-        let uad_version_text = if let Some(r) = &self.settings_view.self_update_state.latest_release
-        {
-            if self.settings_view.self_update_state.status == SelfUpdateStatus::Updating {
-                Text::new("Updating please wait...")
-                    .color(self.settings_view.theme.palette.normal.surface)
-            } else {
-                Text::new(format!(
-                    "New UAD version available {} -> {}",
-                    env!("CARGO_PKG_VERSION"),
-                    r.tag_name
-                ))
-                .color(self.settings_view.theme.palette.normal.surface)
-            }
-        } else {
-            Text::new(env!("CARGO_PKG_VERSION"))
-        };
-
-        let apps_btn = if self
-            .settings_view
-            .self_update_state
-            .latest_release
-            .is_some()
-        {
-            button("Update")
-                .on_press(Message::AboutAction(AboutMessage::DoSelfUpdate))
-                .padding(5)
-                .style(style::SelfUpdateButton(self.settings_view.theme.palette))
-        } else {
-            button("Apps")
-                .on_press(Message::AppsPress)
-                .padding(5)
-                .style(style::PrimaryButton(self.settings_view.theme.palette))
-        };
-
-        let about_btn = button("About")
-            .on_press(Message::AboutPressed)
-            .padding(5)
-            .style(style::PrimaryButton(self.settings_view.theme.palette));
-
-        let settings_btn = button("Settings")
-            .on_press(Message::SettingsPressed)
-            .padding(5)
-            .style(style::PrimaryButton(self.settings_view.theme.palette));
-
-        let device_picklist = pick_list(
-            &self.device_list,
+    fn view(&self) -> Element<Self::Message, Renderer<Self::Theme>> {
+        let navigation_container = nav_menu(
+            &self.devices_list,
             self.selected_device.clone(),
-            Message::DeviceSelected,
-        )
-        .style(style::PickList(self.settings_view.theme.palette));
+            &self.apps_view,
+            &self.update_state.self_update,
+        );
 
-        let device_list_text = match self.apps_view.state {
-            ListState::Loading(ListLoadingState::FindingPhones) => {
-                text("finding connected phone...")
-            }
-            _ => text("no devices/emulators found"),
-        };
-
-        let row = match self.selected_device {
-            Some(_) => row()
-                .width(Length::Fill)
-                .align_items(Alignment::Center)
-                .spacing(10)
-                .push(apps_refresh_btn)
-                .push(reboot_btn)
-                .push(device_picklist)
-                .push(Space::new(Length::Fill, Length::Shrink))
-                .push(uad_version_text)
-                .push(apps_btn)
-                .push(about_btn)
-                .push(settings_btn),
-            None => row()
-                .width(Length::Fill)
-                .align_items(Alignment::Center)
-                .spacing(10)
-                .push(reboot_btn)
-                .push(apps_refresh_btn)
-                .push(device_list_text)
-                .push(Space::new(Length::Fill, Length::Shrink))
-                .push(uad_version_text)
-                .push(apps_btn)
-                .push(about_btn)
-                .push(settings_btn),
-        };
-
-        let navigation_container = container(row)
-            .width(Length::Fill)
-            .padding(10)
-            .style(style::NavigationContainer(self.settings_view.theme.palette));
-
+        let selected_device = self.selected_device.clone().unwrap_or_default();
         let main_container = match self.view {
             View::List => self
                 .apps_view
-                .view(
-                    &self.settings_view,
-                    &self.selected_device.clone().unwrap_or_default(),
-                )
+                .view(&self.settings_view, &selected_device)
                 .map(Message::AppsAction),
             View::About => self
                 .about_view
-                .view(&self.settings_view)
+                .view(&self.update_state)
                 .map(Message::AboutAction),
             View::Settings => self
                 .settings_view
-                .view(&self.selected_device.clone().unwrap_or_default())
+                .view(&selected_device)
                 .map(Message::SettingsAction),
         };
 
-        Pure::new(
-            &mut self.state,
-            column()
-                .width(Length::Fill)
-                .push(navigation_container)
-                .push(main_container),
-        )
-        .into()
+        column![navigation_container, main_container]
+            .width(Length::Fill)
+            .into()
     }
 }
 
@@ -451,26 +301,4 @@ impl UadGui {
         };
         Self::run(settings).unwrap_err();
     }
-
-    pub async fn load_phone_packages(phone: Phone) -> AppsMessage {
-        env::set_var("ANDROID_SERIAL", phone.adb_id);
-        info!("{:-^65}", "-");
-        info!(
-            "ANDROID_SDK: {} | PHONE: {}",
-            phone.android_sdk, phone.model
-        );
-        AppsMessage::LoadPackages
-    }
-
-    pub async fn download_uad_list() -> Message {
-        Message::InitList
-    }
-
-    pub async fn send_self_update_message() -> SettingsMessage {
-        SettingsMessage::GetLatestRelease(get_latest_release())
-    }
-}
-
-fn refresh_icon() -> Text {
-    icon('\u{E900}')
 }

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -1,338 +1,228 @@
-use crate::core::theme::ColorPalette;
-use iced::{button, checkbox, container, pick_list, scrollable, text_input, Background, Color};
+use crate::core::theme::Theme;
+use iced::overlay::menu;
+use iced::widget::{button, checkbox, container, pick_list, scrollable, text, text_input};
+use iced::{application, Background, Color};
 
-pub struct Content(pub ColorPalette);
-impl container::StyleSheet for Content {
-    fn style(&self) -> container::Style {
-        container::Style {
-            background: Some(Background::Color(self.0.base.background)),
-            text_color: Some(self.0.bright.surface),
-            ..container::Style::default()
+#[derive(Debug, Clone, Copy)]
+pub enum Application {
+    Default,
+}
+
+impl Default for Application {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl application::StyleSheet for Theme {
+    type Style = Application;
+
+    fn appearance(&self, _style: Self::Style) -> application::Appearance {
+        application::Appearance {
+            background_color: self.palette.base.background,
+            text_color: self.palette.base.foreground,
         }
     }
 }
 
-pub struct NavigationContainer(pub ColorPalette);
-impl container::StyleSheet for NavigationContainer {
-    fn style(&self) -> container::Style {
-        container::Style {
-            background: Some(Background::Color(self.0.base.foreground)),
-            text_color: Some(self.0.bright.surface),
-            ..container::Style::default()
-        }
+#[derive(Debug, Clone, Copy)]
+pub enum Container {
+    Content,
+    Navigation,
+    Description,
+}
+
+impl Default for Container {
+    fn default() -> Self {
+        Self::Content
     }
 }
 
-pub struct PrimaryButton(pub ColorPalette);
-impl button::StyleSheet for PrimaryButton {
-    fn active(&self) -> button::Style {
-        button::Style {
-            border_color: Color {
-                a: 0.5,
-                ..self.0.bright.primary
-            },
-            border_width: 1.0,
-            border_radius: 2.0,
-            text_color: self.0.bright.primary,
-            ..button::Style::default()
-        }
-    }
+impl container::StyleSheet for Theme {
+    type Style = Container;
 
-    fn hovered(&self) -> button::Style {
-        button::Style {
-            background: Some(Background::Color(Color {
-                a: 0.25,
-                ..self.0.normal.surface
-            })),
-            text_color: self.0.bright.primary,
-            ..self.active()
-        }
-    }
-}
+    fn appearance(&self, style: Self::Style) -> container::Appearance {
+        let from_appearance = |c: Color| container::Appearance {
+            background: Some(Background::Color(c)),
+            text_color: Some(self.palette.bright.surface),
+            ..container::Appearance::default()
+        };
 
-pub struct UnavailableButton(pub ColorPalette);
-impl button::StyleSheet for UnavailableButton {
-    fn active(&self) -> button::Style {
-        button::Style {
-            border_color: Color {
-                a: 0.5,
-                ..self.0.bright.error
-            },
-            border_width: 1.0,
-            border_radius: 2.0,
-            text_color: self.0.bright.error,
-            ..button::Style::default()
-        }
-    }
-
-    fn hovered(&self) -> button::Style {
-        button::Style {
-            background: Some(Background::Color(Color {
-                a: 0.25,
-                ..self.0.normal.primary
-            })),
-            text_color: self.0.normal.error,
-            ..self.active()
-        }
-    }
-}
-
-pub struct SelfUpdateButton(pub ColorPalette);
-impl button::StyleSheet for SelfUpdateButton {
-    fn active(&self) -> button::Style {
-        button::Style {
-            border_color: Color {
-                a: 0.5,
-                ..self.0.bright.secondary
-            },
-            border_width: 1.0,
-            border_radius: 2.0,
-            text_color: self.0.bright.secondary,
-            ..button::Style::default()
-        }
-    }
-
-    fn hovered(&self) -> button::Style {
-        button::Style {
-            background: Some(Background::Color(Color {
-                a: 0.25,
-                ..self.0.normal.surface
-            })),
-            text_color: self.0.bright.secondary,
-            ..self.active()
-        }
-    }
-}
-
-pub struct RefreshButton(pub ColorPalette);
-impl button::StyleSheet for RefreshButton {
-    fn active(&self) -> button::Style {
-        button::Style {
-            border_color: Color {
-                a: 0.5,
-                ..self.0.bright.primary
-            },
-            border_width: 1.0,
-            border_radius: 2.0,
-            text_color: self.0.bright.primary,
-            ..button::Style::default()
-        }
-    }
-
-    fn hovered(&self) -> button::Style {
-        button::Style {
-            background: Some(Background::Color(Color {
-                a: 0.25,
-                ..self.0.normal.surface
-            })),
-            text_color: self.0.bright.primary,
-            ..self.active()
-        }
-    }
-}
-
-pub enum PackageButton {
-    Uninstall(ColorPalette),
-    Restore(ColorPalette),
-}
-
-impl button::StyleSheet for PackageButton {
-    fn active(&self) -> button::Style {
-        match self {
-            Self::Uninstall(palette) => button::Style {
-                border_color: Color {
-                    a: 0.5,
-                    ..palette.bright.error
-                },
-                border_width: 1.0,
-                border_radius: 2.0,
-                text_color: palette.bright.error,
-                ..button::Style::default()
-            },
-            Self::Restore(palette) => button::Style {
-                border_color: Color {
-                    a: 0.5,
-                    ..palette.bright.secondary
-                },
-                border_width: 1.0,
-                border_radius: 2.0,
-                text_color: palette.bright.secondary,
-                ..button::Style::default()
-            },
-        }
-    }
-
-    fn hovered(&self) -> button::Style {
-        match self {
-            Self::Restore(palette) => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.25,
-                    ..palette.normal.primary
-                })),
-                text_color: palette.bright.primary,
-                ..self.active()
-            },
-            Self::Uninstall(palette) => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.25,
-                    ..palette.normal.primary
-                })),
-                text_color: palette.bright.primary,
-                ..self.active()
-            },
-        }
-    }
-
-    fn disabled(&self) -> button::Style {
-        match self {
-            Self::Restore(palette) => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.05,
-                    ..palette.normal.primary
-                })),
-                text_color: Color {
-                    a: 0.50,
-                    ..palette.bright.primary
-                },
-                ..self.active()
-            },
-            Self::Uninstall(palette) => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.01,
-                    ..palette.bright.error
-                })),
-                text_color: Color {
-                    a: 0.50,
-                    ..palette.bright.error
-                },
-                ..self.active()
-            },
-        }
-    }
-}
-
-pub enum PackageRow {
-    Normal(ColorPalette),
-    Current(ColorPalette),
-}
-impl button::StyleSheet for PackageRow {
-    fn active(&self) -> button::Style {
-        match self {
-            Self::Normal(palette) => button::Style {
-                background: Some(Background::Color(palette.base.foreground)),
-                text_color: palette.bright.surface,
+        match style {
+            Container::Content => from_appearance(self.palette.base.background),
+            Container::Navigation => from_appearance(self.palette.base.background),
+            Container::Description => container::Appearance {
+                background: Some(Background::Color(self.palette.base.foreground)),
+                text_color: Some(self.palette.bright.surface),
                 border_radius: 5.0,
                 border_width: 0.0,
-                border_color: palette.base.background,
-                ..button::Style::default()
+                border_color: self.palette.base.background,
             },
-            Self::Current(palette) => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.25,
-                    ..palette.normal.primary
-                })),
-                text_color: palette.bright.primary,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Button {
+    Primary,
+    Unavailable,
+    SelfUpdate,
+    Refresh,
+    UninstallPackage,
+    RestorePackage,
+    NormalPackage,
+    SelectedPackage,
+}
+
+impl Default for Button {
+    fn default() -> Self {
+        Self::Primary
+    }
+}
+
+impl button::StyleSheet for Theme {
+    type Style = Button;
+
+    fn active(&self, style: Self::Style) -> button::Appearance {
+        let p = self.palette;
+
+        let appearance = button::Appearance {
+            border_width: 1.0,
+            border_radius: 2.0,
+            ..button::Appearance::default()
+        };
+
+        let active_appearance = |bg: Option<Color>, mc| button::Appearance {
+            background: Some(Background::Color(bg.unwrap_or(p.base.foreground))),
+            border_color: Color { a: 0.5, ..mc },
+            text_color: mc,
+            ..appearance
+        };
+
+        match style {
+            Button::Primary => active_appearance(None, p.bright.primary),
+            Button::Unavailable => active_appearance(None, p.bright.error),
+            Button::Refresh => active_appearance(None, p.bright.primary),
+            Button::SelfUpdate => active_appearance(None, p.bright.primary),
+            Button::UninstallPackage => active_appearance(None, p.bright.error),
+            Button::RestorePackage => active_appearance(None, p.bright.secondary),
+            Button::NormalPackage => button::Appearance {
+                background: Some(Background::Color(p.base.foreground)),
+                text_color: p.bright.surface,
                 border_radius: 5.0,
                 border_width: 0.0,
-                border_color: palette.normal.primary,
-                ..button::Style::default()
+                border_color: p.base.background,
+                ..appearance
             },
-        }
-    }
-    fn hovered(&self) -> button::Style {
-        match self {
-            Self::Normal(palette) => button::Style {
+            Button::SelectedPackage => button::Appearance {
                 background: Some(Background::Color(Color {
-                    a: 0.30,
-                    ..palette.normal.primary
+                    a: 0.25,
+                    ..p.normal.primary
                 })),
-                text_color: palette.bright.primary,
-                ..self.active()
+                text_color: p.bright.primary,
+                border_radius: 5.0,
+                border_width: 0.0,
+                border_color: p.normal.primary,
+                ..appearance
             },
-            Self::Current(_) => button::Style { ..self.active() },
         }
     }
-    fn pressed(&self) -> button::Style {
-        button::Style { ..self.active() }
+
+    fn hovered(&self, style: Self::Style) -> button::Appearance {
+        let active = self.active(style);
+        let p = self.palette;
+
+        let hover_appearance = |bg, tc: Option<Color>| button::Appearance {
+            background: Some(Background::Color(Color { a: 0.25, ..bg })),
+            text_color: tc.unwrap_or(bg),
+            ..active
+        };
+
+        match style {
+            Button::Primary => hover_appearance(p.bright.primary, None),
+            Button::Unavailable => hover_appearance(p.bright.error, None),
+            Button::Refresh => hover_appearance(p.bright.primary, None),
+            Button::SelfUpdate => hover_appearance(p.bright.primary, None),
+            Button::UninstallPackage => hover_appearance(p.bright.error, None),
+            Button::RestorePackage => hover_appearance(p.bright.secondary, None),
+            Button::NormalPackage => hover_appearance(p.normal.primary, Some(p.bright.surface)),
+            Button::SelectedPackage => hover_appearance(p.normal.primary, None),
+        }
+    }
+
+    fn disabled(&self, style: Self::Style) -> button::Appearance {
+        let active = self.active(style);
+        let p = self.palette;
+
+        let disabled_appearance = |bg, tc: Option<Color>| button::Appearance {
+            background: Some(Background::Color(Color { a: 0.05, ..bg })),
+            text_color: Color {
+                a: 0.50,
+                ..tc.unwrap_or(bg)
+            },
+            ..active
+        };
+
+        match style {
+            Button::RestorePackage => disabled_appearance(p.normal.primary, Some(p.bright.primary)),
+            Button::UninstallPackage => disabled_appearance(p.bright.error, None),
+            _ => button::Appearance { ..active },
+        }
+    }
+
+    fn pressed(&self, style: Self::Style) -> button::Appearance {
+        button::Appearance {
+            ..self.active(style)
+        }
     }
 }
 
-pub struct Description(pub ColorPalette);
-impl container::StyleSheet for Description {
-    fn style(&self) -> container::Style {
-        container::Style {
-            background: Some(Background::Color(self.0.base.foreground)),
-            text_color: Some(self.0.bright.surface),
-            border_radius: 5.0,
-            border_width: 0.0,
-            border_color: self.0.base.background,
-        }
+impl Default for Scrollable {
+    fn default() -> Self {
+        Self::Description
     }
 }
 
-pub struct DescriptionScrollable(pub ColorPalette);
-impl scrollable::StyleSheet for DescriptionScrollable {
-    fn active(&self) -> scrollable::Scrollbar {
-        scrollable::Scrollbar {
-            background: Some(Background::Color(self.0.base.foreground)),
+#[derive(Debug, Clone, Copy)]
+pub enum Scrollable {
+    Description,
+    Packages,
+}
+
+impl scrollable::StyleSheet for Theme {
+    type Style = Scrollable;
+
+    fn active(&self, style: Self::Style) -> scrollable::Scrollbar {
+        let from_appearance = |c: Color| scrollable::Scrollbar {
+            background: Some(Background::Color(c)),
             border_radius: 5.0,
             border_width: 0.0,
             border_color: Color::TRANSPARENT,
             scroller: scrollable::Scroller {
-                color: self.0.base.foreground,
+                color: self.palette.base.foreground,
                 border_radius: 0.0,
                 border_width: 0.0,
                 border_color: Color::TRANSPARENT,
             },
+        };
+
+        match style {
+            Scrollable::Description => from_appearance(self.palette.base.foreground),
+            Scrollable::Packages => from_appearance(self.palette.base.background),
         }
     }
 
-    fn hovered(&self) -> scrollable::Scrollbar {
-        let active = self.active();
-
+    fn hovered(&self, style: Self::Style) -> scrollable::Scrollbar {
         scrollable::Scrollbar {
-            scroller: scrollable::Scroller { ..active.scroller },
-            ..active
-        }
-    }
-
-    fn dragging(&self) -> scrollable::Scrollbar {
-        let hovered = self.hovered();
-        scrollable::Scrollbar {
-            scroller: scrollable::Scroller { ..hovered.scroller },
-            ..hovered
-        }
-    }
-}
-
-pub struct Scrollable(pub ColorPalette);
-impl scrollable::StyleSheet for Scrollable {
-    fn active(&self) -> scrollable::Scrollbar {
-        scrollable::Scrollbar {
-            background: Some(Background::Color(self.0.base.background)),
-            border_radius: 0.0,
-            border_width: 0.0,
-            border_color: Color::TRANSPARENT,
             scroller: scrollable::Scroller {
-                color: self.0.base.foreground,
-                border_radius: 2.0,
-                border_width: 0.0,
-                border_color: Color::TRANSPARENT,
+                ..self.active(style).scroller
             },
+            ..self.active(style)
         }
     }
 
-    fn hovered(&self) -> scrollable::Scrollbar {
-        let active = self.active();
-
-        scrollable::Scrollbar {
-            scroller: scrollable::Scroller { ..active.scroller },
-            ..active
-        }
-    }
-
-    fn dragging(&self) -> scrollable::Scrollbar {
-        let hovered = self.hovered();
+    fn dragging(&self, style: Self::Style) -> scrollable::Scrollbar {
+        let hovered = self.hovered(style);
         scrollable::Scrollbar {
             scroller: scrollable::Scroller { ..hovered.scroller },
             ..hovered
@@ -340,180 +230,216 @@ impl scrollable::StyleSheet for Scrollable {
     }
 }
 
-pub enum SelectionCheckBox {
-    Enabled(ColorPalette),
-    Disabled(ColorPalette),
+#[derive(Debug, Clone, Copy)]
+pub enum CheckBox {
+    PackageEnabled,
+    PackageDisabled,
+    SettingsEnabled,
+    SettingsDisabled,
 }
 
-impl checkbox::StyleSheet for SelectionCheckBox {
-    fn active(&self, _is_checked: bool) -> checkbox::Style {
-        match self {
-            Self::Enabled(palette) => checkbox::Style {
-                background: Background::Color(palette.base.background),
-                checkmark_color: palette.bright.primary,
+impl Default for CheckBox {
+    fn default() -> Self {
+        Self::PackageEnabled
+    }
+}
+
+impl checkbox::StyleSheet for Theme {
+    type Style = CheckBox;
+
+    fn active(&self, style: Self::Style, _is_checked: bool) -> checkbox::Appearance {
+        match style {
+            CheckBox::PackageEnabled => checkbox::Appearance {
+                background: Background::Color(self.palette.base.background),
+                checkmark_color: self.palette.bright.primary,
                 border_radius: 5.0,
                 border_width: 1.0,
-                border_color: palette.base.background,
-                text_color: Some(palette.bright.surface),
+                border_color: self.palette.base.background,
+                text_color: Some(self.palette.bright.surface),
             },
-            Self::Disabled(palette) => checkbox::Style {
+            CheckBox::PackageDisabled => checkbox::Appearance {
                 background: Background::Color(Color {
                     a: 0.55,
-                    ..palette.base.background
+                    ..self.palette.base.background
                 }),
-                checkmark_color: palette.bright.primary,
-                border_radius: 5.0,
-                border_width: 0.0,
-                border_color: palette.normal.primary,
-                text_color: Some(palette.normal.primary),
-            },
-        }
-    }
-
-    fn hovered(&self, is_checked: bool) -> checkbox::Style {
-        match self {
-            Self::Enabled(palette) => checkbox::Style {
-                background: Background::Color(Color {
-                    a: 0.5,
-                    ..palette.bright.primary
-                }),
-                checkmark_color: palette.bright.primary,
-                border_radius: 5.0,
-                border_width: 2.0,
-                border_color: Color {
-                    a: 0.5,
-                    ..palette.bright.primary
-                },
-                text_color: Some(palette.bright.surface),
-            },
-
-            Self::Disabled(_) => checkbox::Style {
-                ..self.active(is_checked)
-            },
-        }
-    }
-}
-
-pub enum SettingsCheckBox {
-    Enabled(ColorPalette),
-    Disabled(ColorPalette),
-}
-
-impl checkbox::StyleSheet for SettingsCheckBox {
-    fn active(&self, _is_checked: bool) -> checkbox::Style {
-        match self {
-            Self::Enabled(palette) => checkbox::Style {
-                background: Background::Color(palette.base.background),
-                checkmark_color: palette.bright.primary,
+                checkmark_color: self.palette.bright.primary,
                 border_radius: 5.0,
                 border_width: 1.0,
-                border_color: palette.bright.primary,
-                text_color: Some(palette.bright.surface),
+                border_color: self.palette.normal.primary,
+                text_color: Some(self.palette.normal.primary),
             },
-            Self::Disabled(palette) => checkbox::Style {
-                background: Background::Color(palette.base.foreground),
-                checkmark_color: palette.bright.primary,
+            CheckBox::SettingsEnabled => checkbox::Appearance {
+                background: Background::Color(self.palette.base.background),
+                checkmark_color: self.palette.bright.primary,
                 border_radius: 5.0,
                 border_width: 1.0,
-                border_color: palette.normal.primary,
-                text_color: Some(palette.normal.primary),
+                border_color: self.palette.bright.primary,
+                text_color: Some(self.palette.bright.surface),
+            },
+            CheckBox::SettingsDisabled => checkbox::Appearance {
+                background: Background::Color(self.palette.base.foreground),
+                checkmark_color: self.palette.bright.primary,
+                border_radius: 5.0,
+                border_width: 1.0,
+                border_color: self.palette.normal.primary,
+                text_color: Some(self.palette.normal.primary),
             },
         }
     }
-    fn hovered(&self, is_checked: bool) -> checkbox::Style {
-        match self {
-            Self::Enabled(palette) => checkbox::Style {
-                background: Background::Color(palette.base.foreground),
-                checkmark_color: palette.bright.primary,
-                border_radius: 5.0,
-                border_width: 2.0,
-                border_color: palette.bright.primary,
-                text_color: Some(palette.bright.surface),
-            },
-            Self::Disabled(_) => checkbox::Style {
-                ..self.active(is_checked)
-            },
+
+    fn hovered(&self, style: Self::Style, is_checked: bool) -> checkbox::Appearance {
+        let from_appearance = || checkbox::Appearance {
+            background: Background::Color(self.palette.base.foreground),
+            checkmark_color: self.palette.bright.primary,
+            border_radius: 5.0,
+            border_width: 2.0,
+            border_color: self.palette.bright.primary,
+            text_color: Some(self.palette.bright.surface),
+        };
+
+        match style {
+            CheckBox::PackageEnabled => from_appearance(),
+            CheckBox::SettingsEnabled => from_appearance(),
+            CheckBox::PackageDisabled => self.active(style, is_checked),
+            CheckBox::SettingsDisabled => self.active(style, is_checked),
         }
     }
 }
 
-pub struct SearchInput(pub ColorPalette);
-impl text_input::StyleSheet for SearchInput {
-    fn active(&self) -> text_input::Style {
-        text_input::Style {
-            background: Background::Color(self.0.base.foreground),
+#[derive(Debug, Clone, Copy)]
+pub enum TextInput {
+    Default,
+}
+
+impl Default for TextInput {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl text_input::StyleSheet for Theme {
+    type Style = TextInput;
+
+    fn active(&self, _style: Self::Style) -> text_input::Appearance {
+        text_input::Appearance {
+            background: Background::Color(self.palette.base.foreground),
             border_radius: 5.0,
             border_width: 0.0,
-            border_color: self.0.base.foreground,
+            border_color: self.palette.base.foreground,
         }
     }
 
-    fn focused(&self) -> text_input::Style {
-        text_input::Style {
-            background: Background::Color(self.0.base.foreground),
+    fn focused(&self, _style: Self::Style) -> text_input::Appearance {
+        text_input::Appearance {
+            background: Background::Color(self.palette.base.foreground),
             border_radius: 2.0,
             border_width: 1.0,
             border_color: Color {
                 a: 0.5,
-                ..self.0.normal.primary
+                ..self.palette.normal.primary
             },
         }
     }
 
-    fn placeholder_color(&self) -> Color {
-        self.0.normal.surface
+    fn placeholder_color(&self, _style: Self::Style) -> Color {
+        self.palette.normal.surface
     }
 
-    fn value_color(&self) -> Color {
-        self.0.bright.primary
+    fn value_color(&self, _style: Self::Style) -> Color {
+        self.palette.bright.primary
     }
 
-    fn selection_color(&self) -> Color {
-        self.0.bright.secondary
+    fn selection_color(&self, _style: Self::Style) -> Color {
+        self.palette.normal.primary
     }
 
     /// Produces the style of an hovered text input.
-    fn hovered(&self) -> text_input::Style {
-        self.focused()
+    fn hovered(&self, style: Self::Style) -> text_input::Appearance {
+        self.focused(style)
     }
 }
 
-pub struct PickList(pub ColorPalette);
-impl pick_list::StyleSheet for PickList {
-    fn menu(&self) -> pick_list::Menu {
-        pick_list::Menu {
-            text_color: self.0.bright.surface,
-            background: Background::Color(self.0.base.foreground),
+#[derive(Debug, Clone, Copy)]
+pub enum PickList {
+    Default,
+}
+
+impl Default for PickList {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl menu::StyleSheet for Theme {
+    type Style = ();
+
+    fn appearance(&self, _style: Self::Style) -> menu::Appearance {
+        let p = self.palette;
+
+        menu::Appearance {
+            text_color: p.bright.surface,
+            background: p.base.background.into(),
             border_width: 1.0,
-            border_color: self.0.base.background,
-            selected_background: Background::Color(Color {
-                a: 0.15,
-                ..self.0.normal.primary
-            }),
-            selected_text_color: self.0.bright.primary,
+            border_radius: 2.0,
+            border_color: p.base.background,
+            selected_text_color: p.bright.surface,
+            selected_background: p.normal.primary.into(),
         }
     }
+}
 
-    fn active(&self) -> pick_list::Style {
-        pick_list::Style {
-            text_color: self.0.bright.surface,
-            background: self.0.base.background.into(),
+impl pick_list::StyleSheet for Theme {
+    type Style = ();
+
+    fn active(&self, _style: ()) -> pick_list::Appearance {
+        pick_list::Appearance {
+            text_color: self.palette.bright.surface,
+            background: self.palette.base.background.into(),
             border_width: 1.0,
             border_color: Color {
                 a: 0.5,
-                ..self.0.normal.primary
+                ..self.palette.normal.primary
             },
             border_radius: 2.0,
             icon_size: 0.5,
-            placeholder_color: self.0.bright.surface,
+            placeholder_color: self.palette.bright.surface,
         }
     }
 
-    fn hovered(&self) -> pick_list::Style {
-        let active = self.active();
-        pick_list::Style {
-            text_color: self.0.bright.primary,
+    fn hovered(&self, style: ()) -> pick_list::Appearance {
+        let active = self.active(style);
+        pick_list::Appearance {
+            text_color: self.palette.bright.primary,
             ..active
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Text {
+    Default,
+    Color(Color),
+}
+
+impl Default for Text {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl From<Color> for Text {
+    fn from(color: Color) -> Self {
+        Text::Color(color)
+    }
+}
+
+impl text::StyleSheet for Theme {
+    type Style = Text;
+
+    fn appearance(&self, style: Self::Style) -> text::Appearance {
+        match style {
+            Text::Default => Default::default(),
+            Text::Color(c) => text::Appearance { color: Some(c) },
         }
     }
 }

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -1,4 +1,5 @@
 use crate::core::sync::{action_handler, Phone, User};
+use crate::core::theme::Theme;
 use crate::core::uad_lists::{
     load_debloat_lists, Opposite, Package, PackageState, Removal, UadList, UadListState,
 };
@@ -11,10 +12,10 @@ use std::env;
 
 use crate::gui::views::settings::Settings;
 use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
-use iced::pure::{
-    button, column, container, pick_list, row, scrollable, text, text_input, Element,
+use iced::widget::{
+    button, column, container, pick_list, row, scrollable, text, text_input, Space,
 };
-use iced::{Alignment, Command, Length, Space};
+use iced::{Alignment, Command, Element, Length, Renderer};
 
 #[derive(Debug, Default, Clone)]
 pub struct Selection {
@@ -30,29 +31,19 @@ pub enum Action {
     Restore,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone)]
 pub enum LoadingState {
-    FindingPhones,
     DownloadingList,
+    #[default]
+    FindingPhones,
     LoadingPackages,
     _UpdatingUad,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum State {
     Ready,
-    Loading(LoadingState),
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::Loading(LoadingState::LoadingPackages)
-    }
 }
 
 #[derive(Default, Debug, Clone)]
 pub struct List {
-    pub state: State,
+    pub loading_state: LoadingState,
     pub uad_lists: HashMap<String, Package>,
     phone_packages: Vec<Vec<PackageRow>>, // packages of all users of the phone
     filtered_packages: Vec<usize>, // phone_packages indexes of the selected user (= what you see on screen)
@@ -68,11 +59,11 @@ pub struct List {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    LoadUadList(bool),
+    LoadPhonePackages((HashMap<String, Package>, UadListState)),
+    ApplyFilters(Vec<Vec<PackageRow>>),
     SearchInputChanged(String),
     ToggleAllSelected(bool),
-    InitUadList(bool),
-    ListsIsInitialized((Result<HashMap<String, Package>, ()>, bool)),
-    LoadPackages,
     ListSelected(UadList),
     UserSelected(User),
     PackageStateSelected(PackageState),
@@ -82,7 +73,6 @@ pub enum Message {
     List(usize, RowMessage),
     ExportedSelection(Result<bool, String>),
     ChangePackageState(Result<usize, ()>),
-    PackagesLoaded(Vec<Vec<PackageRow>>),
     Nothing,
 }
 
@@ -90,69 +80,54 @@ impl List {
     pub fn update(
         &mut self,
         settings: &mut Settings,
-        phone: &mut Phone,
+        selected_device: &mut Phone,
+        list_update_state: &mut UadListState,
         message: Message,
     ) -> Command<Message> {
-        let i_user = &self.selected_user.unwrap_or(User { id: 0, index: 0 }).index;
+        let i_user = self.selected_user.unwrap_or(User { id: 0, index: 0 }).index;
         match message {
-            Message::Nothing => Command::none(),
-            Message::InitUadList(remote) => {
-                self.state = State::Loading(LoadingState::FindingPhones);
-                if remote {
-                    Command::perform(load_debloat_lists(true), Message::ListsIsInitialized)
-                } else {
-                    Command::perform(load_debloat_lists(false), Message::ListsIsInitialized)
-                }
-            }
-            Message::ListsIsInitialized((uad_lists, remote)) => match uad_lists {
-                Ok(list) => {
-                    if !remote {
-                        settings.list_update_state = UadListState::Failed;
-                    } else {
-                        settings.list_update_state = UadListState::Done;
-                    }
-                    self.uad_lists = list;
-                    if !phone.adb_id.is_empty() {
-                        env::set_var("ANDROID_SERIAL", phone.adb_id.clone());
-                        Command::perform(Self::do_load_packages(), |_| Message::LoadPackages)
-                    } else {
-                        Command::none()
-                    }
-                }
-                Err(_) => Command::none(),
-            },
-            Message::LoadPackages => {
-                self.state = State::Loading(LoadingState::LoadingPackages);
-                self.selected_package_state = Some(PackageState::Enabled);
-                self.selected_list = Some(UadList::All);
-                self.selected_removal = Some(Removal::Recommended);
-                self.selected_user = Some(User { id: 0, index: 0 });
+            Message::LoadUadList(remote) => {
+                self.loading_state = LoadingState::DownloadingList;
                 Command::perform(
-                    Self::load_packages(self.uad_lists.clone(), phone.user_list.clone()),
-                    Message::PackagesLoaded,
+                    Self::init_apps_view(remote, selected_device.clone()),
+                    Message::LoadPhonePackages,
                 )
             }
-            Message::PackagesLoaded(packages) => {
+            Message::LoadPhonePackages(list_box) => {
+                let (uad_list, list_state) = list_box;
+                self.loading_state = LoadingState::LoadingPackages;
+                self.uad_lists = uad_list.clone();
+                *list_update_state = list_state;
+                Command::perform(
+                    Self::load_packages(uad_list, selected_device.user_list.clone()),
+                    Message::ApplyFilters,
+                )
+            }
+            Message::ApplyFilters(packages) => {
                 self.phone_packages = packages;
-                self.filtered_packages = (0..self.phone_packages[*i_user].len()).collect();
+                self.filtered_packages = (0..self.phone_packages[i_user].len()).collect();
+                self.selected_package_state = Some(PackageState::Enabled);
+                self.selected_removal = Some(Removal::Recommended);
+                self.selected_list = Some(UadList::All);
+                self.selected_user = Some(User { id: 0, index: 0 });
                 Self::filter_package_lists(self);
 
-                match import_selection(&mut self.phone_packages[*i_user], &mut self.selection) {
+                match import_selection(&mut self.phone_packages[i_user], &mut self.selection) {
                     Ok(_) => info!("Custom selection has been successfully imported"),
                     Err(err) => warn!("No custom selection imported: {}", err),
                 };
-                self.state = State::Ready;
+                self.loading_state = LoadingState::Ready;
                 Command::none()
             }
             Message::ToggleAllSelected(selected) => {
                 for i in self.filtered_packages.clone() {
-                    self.phone_packages[*i_user][i].selected = selected;
+                    self.phone_packages[i_user][i].selected = selected;
 
                     if !selected {
                         if self.selection.selected_packages.contains(&i) {
                             update_selection_count(
                                 &mut self.selection,
-                                self.phone_packages[*i_user][i].state,
+                                self.phone_packages[i_user][i].state,
                                 false,
                             );
                             self.selection
@@ -163,7 +138,7 @@ impl List {
                         self.selection.selected_packages.push(i);
                         update_selection_count(
                             &mut self.selection,
-                            self.phone_packages[*i_user][i].state,
+                            self.phone_packages[i_user][i].state,
                             true,
                         );
                     }
@@ -191,11 +166,11 @@ impl List {
                 Command::none()
             }
             Message::List(i_package, row_message) => {
-                self.phone_packages[*i_user][i_package]
+                self.phone_packages[i_user][i_package]
                     .update(row_message.clone())
                     .map(move |row_message| Message::List(i_package, row_message));
 
-                let package = &mut self.phone_packages[*i_user][i_package];
+                let package = &mut self.phone_packages[i_user][i_package];
 
                 match row_message {
                     RowMessage::ToggleSelection(toggle) => {
@@ -224,7 +199,7 @@ impl List {
                         let actions = action_handler(
                             &self.selected_user.unwrap(),
                             package,
-                            phone,
+                            selected_device,
                             &settings.phone,
                         );
 
@@ -256,8 +231,7 @@ impl List {
                         self.description = package.clone().description;
                         package.current = true;
                         if self.current_package_index != i_package {
-                            self.phone_packages[*i_user][self.current_package_index].current =
-                                false;
+                            self.phone_packages[i_user][self.current_package_index].current = false;
                         }
                         self.current_package_index = i_package;
                         Command::none()
@@ -270,12 +244,12 @@ impl List {
                 match action {
                     Action::Remove => {
                         selected_packages.drain_filter(|i| {
-                            self.phone_packages[*i_user][*i].state != PackageState::Enabled
+                            self.phone_packages[i_user][*i].state != PackageState::Enabled
                         });
                     }
                     Action::Restore => {
                         selected_packages.drain_filter(|i| {
-                            self.phone_packages[*i_user][*i].state == PackageState::Enabled
+                            self.phone_packages[i_user][*i].state == PackageState::Enabled
                         });
                     }
                 }
@@ -283,8 +257,8 @@ impl List {
                 for i in selected_packages {
                     let actions = action_handler(
                         &self.selected_user.unwrap(),
-                        &self.phone_packages[*i_user][i],
-                        phone,
+                        &self.phone_packages[i_user][i],
+                        selected_device,
                         &settings.phone,
                     );
                     for (j, action) in actions.into_iter().enumerate() {
@@ -294,7 +268,7 @@ impl List {
                                 perform_commands(
                                     action,
                                     i,
-                                    self.phone_packages[*i_user][i].removal.to_string(),
+                                    self.phone_packages[i_user][i].removal.to_string(),
                                 ),
                                 |_| Message::Nothing,
                             ));
@@ -303,7 +277,7 @@ impl List {
                                 perform_commands(
                                     action,
                                     i,
-                                    self.phone_packages[*i_user][i].removal.to_string(),
+                                    self.phone_packages[i_user][i].removal.to_string(),
                                 ),
                                 Message::ChangePackageState,
                             ));
@@ -313,7 +287,7 @@ impl List {
                 Command::batch(commands)
             }
             Message::ExportSelectionPressed => Command::perform(
-                export_selection(self.phone_packages[*i_user].clone()),
+                export_selection(self.phone_packages[i_user].clone()),
                 Message::ExportedSelection,
             ),
             Message::ExportedSelection(export) => {
@@ -324,7 +298,7 @@ impl List {
                 Command::none()
             }
             Message::UserSelected(user) => {
-                for p in &mut self.phone_packages[*i_user] {
+                for p in &mut self.phone_packages[i_user] {
                     p.selected = false;
                 }
                 self.selected_user = Some(user);
@@ -337,14 +311,14 @@ impl List {
             }
             Message::ChangePackageState(res) => {
                 if let Ok(i) = res {
-                    let package = &mut self.phone_packages[*i_user][i];
+                    let package = &mut self.phone_packages[i_user][i];
                     update_selection_count(&mut self.selection, package.state, false);
 
                     if !settings.phone.multi_user_mode {
                         package.state = package.state.opposite(settings.phone.disable_mode);
                         package.selected = false;
                     } else {
-                        for u in &phone.user_list {
+                        for u in &selected_device.user_list {
                             self.phone_packages[u.index][i].state = self.phone_packages[u.index][i]
                                 .state
                                 .opposite(settings.phone.disable_mode);
@@ -358,123 +332,112 @@ impl List {
                 }
                 Command::none()
             }
+            Message::Nothing => Command::none(),
         }
     }
 
-    pub fn view(&mut self, settings: &Settings, phone: &Phone) -> Element<Message> {
-        match self.state {
-            State::Loading(LoadingState::DownloadingList) => {
+    pub fn view(
+        &self,
+        settings: &Settings,
+        selected_device: &Phone,
+    ) -> Element<Message, Renderer<Theme>> {
+        match self.loading_state {
+            LoadingState::DownloadingList => {
                 let text = "Downloading latest UAD lists from Github. Please wait...";
                 waiting_view(settings, text, true)
             }
-            State::Loading(LoadingState::FindingPhones) => {
+            LoadingState::FindingPhones => {
                 let text = "Finding connected devices...";
                 waiting_view(settings, text, false)
             }
-            State::Loading(LoadingState::LoadingPackages) => {
-                let text = "Pulling packages from the phone. Please wait...";
+            LoadingState::LoadingPackages => {
+                let text = "Pulling packages from the device. Please wait...";
                 waiting_view(settings, text, false)
             }
-            State::Loading(LoadingState::_UpdatingUad) => {
+            LoadingState::_UpdatingUad => {
                 let text = "Updating UAD. Please wait...";
                 waiting_view(settings, text, false)
             }
-            State::Ready => {
+            LoadingState::Ready => {
                 let search_packages = text_input(
                     "Search packages...",
                     &self.input_value,
                     Message::SearchInputChanged,
                 )
-                .padding(5)
-                .style(style::SearchInput(settings.theme.palette));
+                .padding(5);
 
                 // let package_amount = text(format!("{} packages found", packages.len()));
 
                 let user_picklist = pick_list(
-                    phone.user_list.clone(),
+                    selected_device.user_list.clone(),
                     self.selected_user,
                     Message::UserSelected,
                 )
-                .width(Length::Units(85))
-                .style(style::PickList(settings.theme.palette));
+                .width(Length::Units(85));
 
                 let divider = Space::new(Length::Fill, Length::Shrink);
 
                 let list_picklist =
-                    pick_list(&UadList::ALL[..], self.selected_list, Message::ListSelected)
-                        .style(style::PickList(settings.theme.palette));
-
+                    pick_list(&UadList::ALL[..], self.selected_list, Message::ListSelected);
                 let package_state_picklist = pick_list(
                     &PackageState::ALL[..],
                     self.selected_package_state,
                     Message::PackageStateSelected,
-                )
-                .style(style::PickList(settings.theme.palette));
+                );
 
                 let removal_picklist = pick_list(
                     &Removal::ALL[..],
                     self.selected_removal,
                     Message::RemovalSelected,
-                )
-                .style(style::PickList(settings.theme.palette));
+                );
 
-                let control_panel = row()
-                    .width(Length::Fill)
-                    .align_items(Alignment::Center)
-                    .spacing(10)
-                    .padding([0, 16, 0, 0])
-                    .push(search_packages)
-                    .push(user_picklist)
-                    .push(divider)
-                    .push(removal_picklist)
-                    .push(package_state_picklist)
-                    .push(list_picklist);
+                let control_panel = row![
+                    search_packages,
+                    user_picklist,
+                    divider,
+                    removal_picklist,
+                    package_state_picklist,
+                    list_picklist,
+                ]
+                .width(Length::Fill)
+                .align_items(Alignment::Center)
+                .spacing(10)
+                .padding([0, 16, 0, 0]);
 
-                let packages = self.phone_packages[self.selected_user.unwrap().index]
-                    .iter_mut()
-                    .enumerate()
-                    .filter(|(i, _)| self.filtered_packages.contains(i))
-                    .fold(column().spacing(6), |col, (i, p)| {
-                        col.push(
-                            p.view(settings, phone)
-                                .map(move |msg| Message::List(i, msg)),
-                        )
-                    });
-
-                /*
-                // Seems better to me but I can't fix the lifetime issues
-                let packages = self.filtered_packages
-                    .into_iter()
-                    .fold(column().spacing(6), |col, i| {
-                        col.push(self.phone_packages[self.selected_user.unwrap().index][i].view().map(move |msg| Message::List(i, msg)))
-                    });
-                */
+                let packages =
+                    self.filtered_packages
+                        .iter()
+                        .fold(column![].spacing(6), |col, i| {
+                            col.push(
+                                self.phone_packages[self.selected_user.unwrap().index][*i]
+                                    .view(settings, selected_device)
+                                    .map(move |msg| Message::List(*i, msg)),
+                            )
+                        });
 
                 let packages_scrollable = scrollable(packages)
                     .scrollbar_margin(2)
                     .height(Length::FillPortion(6))
-                    .style(style::Scrollable(settings.theme.palette));
+                    .style(style::Scrollable::Packages);
 
                 // let mut packages_v: Vec<&str> = self.packages.lines().collect();
 
                 let description_scroll = scrollable(text(&self.description))
                     .scrollbar_margin(7)
-                    .style(style::DescriptionScrollable(settings.theme.palette));
+                    .style(style::Scrollable::Description);
 
                 let description_panel = container(description_scroll)
                     .height(Length::FillPortion(2))
                     .width(Length::Fill)
-                    .style(style::Description(settings.theme.palette));
+                    .style(style::Container::Description);
 
-                let restore_action = if settings.phone.disable_mode {
-                    "Enable/Restore"
-                } else {
-                    "Restore"
+                let restore_action = match settings.phone.disable_mode {
+                    true => "Enable/Restore",
+                    false => "Restore",
                 };
-                let remove_action = if settings.phone.disable_mode {
-                    "Disable"
-                } else {
-                    "Uninstall"
+                let remove_action = match settings.phone.disable_mode {
+                    true => "Disable",
+                    false => "Uninstall",
                 };
 
                 let apply_restore_selection = button(text(format!(
@@ -484,7 +447,7 @@ impl List {
                 )))
                 .on_press(Message::ApplyActionOnSelection(Action::Restore))
                 .padding(5)
-                .style(style::PrimaryButton(settings.theme.palette));
+                .style(style::Button::Primary);
 
                 let apply_remove_selection = button(text(format!(
                     "{} selection ({})",
@@ -492,17 +455,17 @@ impl List {
                 )))
                 .on_press(Message::ApplyActionOnSelection(Action::Remove))
                 .padding(5)
-                .style(style::PrimaryButton(settings.theme.palette));
+                .style(style::Button::Primary);
 
                 let select_all_btn = button("Select all")
                     .padding(5)
                     .on_press(Message::ToggleAllSelected(true))
-                    .style(style::PrimaryButton(settings.theme.palette));
+                    .style(style::Button::Primary);
 
                 let unselect_all_btn = button("Unselect all")
                     .padding(5)
                     .on_press(Message::ToggleAllSelected(false))
-                    .style(style::PrimaryButton(settings.theme.palette));
+                    .style(style::Button::Primary);
 
                 let export_selection_btn = button(text(format!(
                     "Export current selection ({})",
@@ -510,32 +473,34 @@ impl List {
                 )))
                 .padding(5)
                 .on_press(Message::ExportSelectionPressed)
-                .style(style::PrimaryButton(settings.theme.palette));
+                .style(style::Button::Primary);
 
-                let action_row = row()
-                    .width(Length::Fill)
-                    .spacing(10)
-                    .align_items(Alignment::Center)
-                    .push(select_all_btn)
-                    .push(unselect_all_btn)
-                    .push(Space::new(Length::Fill, Length::Shrink))
-                    .push(export_selection_btn)
-                    .push(apply_restore_selection)
-                    .push(apply_remove_selection);
+                let action_row = row![
+                    select_all_btn,
+                    unselect_all_btn,
+                    Space::new(Length::Fill, Length::Shrink),
+                    export_selection_btn,
+                    apply_restore_selection,
+                    apply_remove_selection,
+                ]
+                .width(Length::Fill)
+                .spacing(10)
+                .align_items(Alignment::Center);
 
-                let content = column()
-                    .width(Length::Fill)
-                    .spacing(10)
-                    .align_items(Alignment::Center)
-                    .push(control_panel)
-                    .push(packages_scrollable)
-                    .push(description_panel)
-                    .push(action_row);
+                let content = column![
+                    control_panel,
+                    packages_scrollable,
+                    description_panel,
+                    action_row,
+                ]
+                .width(Length::Fill)
+                .spacing(10)
+                .align_items(Alignment::Center);
 
                 container(content)
                     .height(Length::Fill)
                     .padding(10)
-                    .style(style::Content(settings.theme.palette))
+                    .style(style::Container::Content)
                     .into()
             }
         }
@@ -559,41 +524,68 @@ impl List {
             .collect();
     }
 
-    async fn do_load_packages() -> Message {
-        Message::LoadPackages
-    }
-
     async fn load_packages(
-        uad_lists: HashMap<String, Package>,
+        uad_list: HashMap<String, Package>,
         user_list: Vec<User>,
     ) -> Vec<Vec<PackageRow>> {
-        let mut temp = vec![];
-        match user_list.len() {
-            0 | 1 => temp.push(fetch_packages(&uad_lists, &None)),
-            _ => {
-                for user in &user_list {
-                    temp.push(fetch_packages(&uad_lists, &Some(user)));
+        let mut phone_packages = vec![];
+
+        if user_list.len() <= 1 {
+            phone_packages.push(fetch_packages(&uad_list, None))
+        } else {
+            phone_packages.extend(
+                user_list
+                    .iter()
+                    .map(|user| fetch_packages(&uad_list, Some(user))),
+            )
+        };
+        phone_packages
+    }
+
+    async fn init_apps_view(
+        remote: bool,
+        phone: Phone,
+    ) -> (HashMap<String, Package>, UadListState) {
+        let (uad_lists, remote) = load_debloat_lists(remote);
+        match uad_lists {
+            Ok(list) => {
+                env::set_var("ANDROID_SERIAL", phone.adb_id.clone());
+                if phone.adb_id.is_empty() {
+                    error!("AppsView ready but no phone found");
+                }
+
+                if !remote {
+                    (list, UadListState::Failed)
+                } else {
+                    (list, UadListState::Done)
                 }
             }
+            Err(_) => {
+                error!("Error loading debloat list for the phone");
+                (HashMap::new(), UadListState::Failed)
+            }
         }
-        temp
     }
 }
 
-fn waiting_view<'a>(settings: &Settings, displayed_text: &str, btn: bool) -> Element<'a, Message> {
+fn waiting_view<'a>(
+    _settings: &Settings,
+    displayed_text: &str,
+    btn: bool,
+) -> Element<'a, Message, Renderer<Theme>> {
     let col = if btn {
         let no_internet_btn = button("No internet?")
             .padding(5)
-            .on_press(Message::InitUadList(false))
-            .style(style::PrimaryButton(settings.theme.palette));
+            .on_press(Message::LoadUadList(false))
+            .style(style::Button::Primary);
 
-        column()
+        column![]
             .spacing(10)
             .align_items(Alignment::Center)
             .push(text(displayed_text).size(20))
             .push(no_internet_btn)
     } else {
-        column()
+        column![]
             .spacing(10)
             .align_items(Alignment::Center)
             .push(text(displayed_text).size(20))
@@ -604,6 +596,6 @@ fn waiting_view<'a>(settings: &Settings, displayed_text: &str, btn: bool) -> Ele
         .height(Length::Fill)
         .center_y()
         .center_x()
-        .style(style::Content(settings.theme.palette))
+        .style(style::Container::Content)
         .into()
 }

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -1,23 +1,18 @@
 use crate::core::config::Config;
 use crate::core::sync::{get_android_sdk, Phone as CorePhone};
 use crate::core::theme::Theme;
-use crate::core::uad_lists::UadListState;
-use crate::core::update::{Release, SelfUpdateState, SelfUpdateStatus};
 use crate::core::utils::{open_url, string_to_theme};
 use crate::gui::style;
 use crate::IN_FILE_CONFIGURATION;
 
-use iced::pure::widget::Text;
-use iced::pure::{button, checkbox, column, container, pick_list, row, text, Element};
-use iced::{Length, Space};
+use iced::widget::{button, checkbox, column, container, pick_list, row, text, Space};
+use iced::{Element, Length, Renderer};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub phone: Phone,
     pub theme: Theme,
-    pub self_update_state: SelfUpdateState,
-    pub list_update_state: UadListState,
 }
 
 #[derive(Debug, Clone)]
@@ -42,8 +37,6 @@ impl Default for Settings {
         Self {
             phone: Phone::default(),
             theme: string_to_theme(IN_FILE_CONFIGURATION.theme.clone()),
-            self_update_state: SelfUpdateState::default(),
-            list_update_state: UadListState::default(),
         }
     }
 }
@@ -55,21 +48,11 @@ pub enum Message {
     MultiUserMode(bool),
     ApplyTheme(Theme),
     UrlPressed(PathBuf),
-    GetLatestRelease(Result<Option<Release>, ()>),
 }
 
 impl Settings {
     pub fn update(&mut self, phone: &CorePhone, msg: Message) {
         match msg {
-            Message::GetLatestRelease(release) => {
-                match release {
-                    Ok(r) => {
-                        self.self_update_state.status = SelfUpdateStatus::Done;
-                        self.self_update_state.latest_release = r
-                    }
-                    Err(_) => self.self_update_state.status = SelfUpdateStatus::Failed,
-                };
-            }
             Message::ExpertMode(toggled) => {
                 info!(
                     "Expert mode {}",
@@ -103,58 +86,52 @@ impl Settings {
         }
     }
 
-    pub fn view(&mut self, phone: &CorePhone) -> Element<Message> {
+    pub fn view(&self, phone: &CorePhone) -> Element<Message, Renderer<Theme>> {
         let general_category_text = text("General").size(25);
 
-        let theme_picklist = pick_list(Theme::all(), Some(self.theme.clone()), Message::ApplyTheme)
-            .style(style::PickList(self.theme.palette));
+        let theme_picklist = pick_list(Theme::all(), Some(self.theme.clone()), Message::ApplyTheme);
 
         let uad_category_text = text("Non-persistent settings").size(25);
 
         let expert_mode_descr =
-            text("Most of unsafe packages are known to bootloop the device if removed.")
-                .size(15)
-                .color(self.theme.palette.normal.surface);
+            text("Most of unsafe packages are known to bootloop the device if removed.").size(15);
 
         let expert_mode_checkbox = checkbox(
             "Allow to uninstall packages marked as \"unsafe\" (I KNOW WHAT I AM DOING)",
             self.phone.expert_mode,
             Message::ExpertMode,
         )
-        .style(style::SettingsCheckBox::Enabled(self.theme.palette));
+        .style(style::CheckBox::SettingsEnabled);
 
         let multi_user_mode_descr =
             text("Disabling this setting will typically prevent affecting your work profile")
-                .size(15)
-                .color(self.theme.palette.normal.surface);
+                .size(15);
 
         let multi_user_mode_checkbox = checkbox(
             "Affect all the users of the phone (not only the selected user)",
             self.phone.multi_user_mode,
             Message::MultiUserMode,
         )
-        .style(style::SettingsCheckBox::Enabled(self.theme.palette));
+        .style(style::CheckBox::SettingsEnabled);
 
-        let disable_color = if phone.android_sdk >= 23 {
+        let _disable_color = if phone.android_sdk >= 23 {
             self.theme.palette.normal.surface
         } else {
             self.theme.palette.normal.primary
         };
 
         let disable_checkbox_style = if phone.android_sdk >= 23 {
-            style::SettingsCheckBox::Enabled(self.theme.palette)
+            style::CheckBox::SettingsEnabled
         } else {
-            style::SettingsCheckBox::Disabled(self.theme.palette)
+            style::CheckBox::SettingsDisabled
         };
 
         let disable_mode_descr =
             text("In some cases, it can be better to disable a package instead of uninstalling it")
-                .size(15)
-                .color(disable_color);
+                .size(15);
 
-        let _unavailable_text = Text::new("[Unavailable before Android 8.0]")
-            .size(16)
-            .color(self.theme.palette.bright.error);
+        /*        let _unavailable_text = text("[Unavailable before Android 8.0]")
+        .size(16);*/
 
         let unavailable_btn = button(text("Unavailable").size(13))
             .on_press(Message::UrlPressed(PathBuf::from(
@@ -162,7 +139,7 @@ impl Settings {
                     why-is-the-disable-mode-setting-not-available-for-my-device",
             )))
             .height(Length::Units(22))
-            .style(style::UnavailableButton(self.theme.palette));
+            .style(style::Button::Unavailable);
 
         // Disabling package without root isn't really possible before Android Oreo (8.0)
         // see https://github.com/0x192/universal-android-debloater/wiki/ADB-reference
@@ -174,40 +151,43 @@ impl Settings {
         .style(disable_checkbox_style);
 
         let disable_setting_row = if phone.android_sdk >= 23 {
-            row()
-                .width(Length::Fill)
-                .push(disable_mode_checkbox)
-                .push(Space::new(Length::Fill, Length::Shrink))
+            row![
+                disable_mode_checkbox,
+                Space::new(Length::Fill, Length::Shrink),
+            ]
+            .width(Length::Fill)
         } else {
-            row()
-                .width(Length::Fill)
-                .push(disable_mode_checkbox)
-                .push(Space::new(Length::Fill, Length::Shrink))
-                .push(unavailable_btn)
+            row![
+                disable_mode_checkbox,
+                Space::new(Length::Fill, Length::Shrink),
+                unavailable_btn,
+            ]
+            .width(Length::Fill)
         };
 
-        let content = column()
-            .width(Length::Fill)
-            .spacing(10)
-            .push(general_category_text)
-            .push("Theme")
-            .push(theme_picklist)
-            .push(Space::new(Length::Fill, Length::Shrink))
-            .push(uad_category_text)
-            .push(expert_mode_checkbox)
-            .push(expert_mode_descr)
-            .push(Space::new(Length::Fill, Length::Shrink))
-            .push(multi_user_mode_checkbox)
-            .push(multi_user_mode_descr)
-            .push(Space::new(Length::Fill, Length::Shrink))
-            .push(disable_setting_row)
-            .push(disable_mode_descr);
+        let content = column![
+            general_category_text,
+            "Theme",
+            theme_picklist,
+            Space::new(Length::Fill, Length::Shrink),
+            uad_category_text,
+            expert_mode_checkbox,
+            expert_mode_descr,
+            Space::new(Length::Fill, Length::Shrink),
+            multi_user_mode_checkbox,
+            multi_user_mode_descr,
+            Space::new(Length::Fill, Length::Shrink),
+            disable_setting_row,
+            disable_mode_descr,
+        ]
+        .width(Length::Fill)
+        .spacing(10);
 
         container(content)
             .padding(10)
             .width(Length::Fill)
             .height(Length::Fill)
-            .style(style::Content(self.theme.palette))
+            .style(style::Container::Content)
             .into()
     }
 }

--- a/src/gui/widgets/mod.rs
+++ b/src/gui/widgets/mod.rs
@@ -1,1 +1,2 @@
+pub mod navigation_menu;
 pub mod package_row;

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -1,0 +1,112 @@
+pub use crate::core::sync::Phone;
+use crate::core::theme::Theme;
+use crate::core::update::{SelfUpdateState, SelfUpdateStatus};
+pub use crate::gui::views::about::Message as AboutMessage;
+pub use crate::gui::views::list::{List as AppsView, LoadingState as ListLoadingState};
+use crate::gui::{style, Message};
+use iced::widget::{button, container, pick_list, row, text, Space, Text};
+use iced::{alignment, Alignment, Element, Font, Length, Renderer};
+
+pub const ICONS: Font = Font::External {
+    name: "Icons",
+    bytes: include_bytes!("../../../resources/assets/icons.ttf"),
+};
+
+pub fn nav_menu<'a>(
+    device_list: &'a Vec<Phone>,
+    selected_device: Option<Phone>,
+    apps_view: &AppsView,
+    self_update_state: &SelfUpdateState,
+) -> Element<'a, Message, Renderer<Theme>> {
+    let apps_refresh_btn = button(
+        Text::new('\u{E900}')
+            .font(ICONS)
+            .width(Length::Units(17))
+            .horizontal_alignment(alignment::Horizontal::Center)
+            .size(17),
+    )
+    .on_press(Message::RefreshButtonPressed)
+    .padding(5)
+    .style(style::Button::Refresh);
+
+    let reboot_btn = button("Reboot")
+        .on_press(Message::RebootButtonPressed)
+        .padding(5)
+        .style(style::Button::Refresh);
+
+    let uad_version_text = if let Some(r) = &self_update_state.latest_release {
+        if self_update_state.status == SelfUpdateStatus::Updating {
+            Text::new("Updating please wait...")
+        } else {
+            Text::new(format!(
+                "New UAD version available {} -> {}",
+                env!("CARGO_PKG_VERSION"),
+                r.tag_name
+            ))
+        }
+    } else {
+        Text::new(env!("CARGO_PKG_VERSION"))
+    };
+
+    let mut apps_btn = button("Apps")
+        .on_press(Message::AppsPress)
+        .padding(5)
+        .style(style::Button::Primary);
+
+    if self_update_state.latest_release.is_some() {
+        apps_btn = button("Update")
+            .on_press(Message::AboutAction(AboutMessage::DoSelfUpdate))
+            .padding(5)
+            .style(style::Button::SelfUpdate);
+    }
+
+    let about_btn = button("About")
+        .on_press(Message::AboutPressed)
+        .padding(5)
+        .style(style::Button::Primary);
+
+    let settings_btn = button("Settings")
+        .on_press(Message::SettingsPressed)
+        .padding(5)
+        .style(style::Button::Primary);
+
+    let device_list_text = match apps_view.loading_state {
+        ListLoadingState::FindingPhones => text("finding connected phone..."),
+        _ => text("no devices/emulators found"),
+    };
+
+    let row = match selected_device {
+        Some(phone) => row![
+            apps_refresh_btn,
+            reboot_btn,
+            pick_list(device_list, Some(phone), Message::DeviceSelected,),
+            Space::new(Length::Fill, Length::Shrink),
+            uad_version_text,
+            apps_btn,
+            about_btn,
+            settings_btn,
+        ]
+        .width(Length::Fill)
+        .align_items(Alignment::Center)
+        .spacing(10),
+        None => row![
+            reboot_btn,
+            apps_refresh_btn,
+            device_list_text,
+            Space::new(Length::Fill, Length::Shrink),
+            uad_version_text,
+            apps_btn,
+            about_btn,
+            settings_btn,
+        ]
+        .width(Length::Fill)
+        .align_items(Alignment::Center)
+        .spacing(10),
+    };
+
+    container(row)
+        .width(Length::Fill)
+        .padding(10)
+        .style(style::Container::Navigation)
+        .into()
+}

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -1,11 +1,11 @@
 use crate::core::sync::Phone;
+use crate::core::theme::Theme;
 use crate::core::uad_lists::{PackageState, Removal, UadList};
-
 use crate::gui::style;
 use crate::gui::views::settings::Settings;
 
-use iced::pure::{button, checkbox, row, text, Element};
-use iced::{alignment, Alignment, Command, Length, Space};
+use iced::widget::{button, checkbox, row, text, Space};
+use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 
 #[derive(Clone, Debug)]
 pub struct PackageRow {
@@ -50,7 +50,7 @@ impl PackageRow {
         Command::none()
     }
 
-    pub fn view(&mut self, settings: &Settings, _phone: &Phone) -> Element<Message> {
+    pub fn view(&self, settings: &Settings, _phone: &Phone) -> Element<Message, Renderer<Theme>> {
         //let trash_svg = format!("{}/resources/assets/trash.svg", env!("CARGO_MANIFEST_DIR"));
         //let restore_svg = format!("{}/resources/assets/rotate.svg", env!("CARGO_MANIFEST_DIR"));
         let button_style;
@@ -65,19 +65,19 @@ impl PackageRow {
                 } else {
                     "Uninstall"
                 };
-                button_style = style::PackageButton::Uninstall(settings.theme.palette);
+                button_style = style::Button::UninstallPackage;
             }
             PackageState::Disabled => {
                 action_text = "Enable";
-                button_style = style::PackageButton::Restore(settings.theme.palette);
+                button_style = style::Button::RestorePackage;
             }
             PackageState::Uninstalled => {
                 action_text = "Restore";
-                button_style = style::PackageButton::Restore(settings.theme.palette);
+                button_style = style::Button::RestorePackage;
             }
             PackageState::All => {
                 action_text = "Error";
-                button_style = style::PackageButton::Restore(settings.theme.palette);
+                button_style = style::Button::RestorePackage;
                 warn!("Incredible! Something impossible happened!");
             }
         }
@@ -87,7 +87,7 @@ impl PackageRow {
             || settings.phone.expert_mode
         {
             selection_checkbox = checkbox("", self.selected, Message::ToggleSelection)
-                .style(style::SelectionCheckBox::Enabled(settings.theme.palette));
+                .style(style::CheckBox::PackageEnabled);
 
             action_btn = button(
                 text(action_text)
@@ -97,7 +97,7 @@ impl PackageRow {
             .on_press(Message::ActionPressed);
         } else {
             selection_checkbox = checkbox("", self.selected, Message::ToggleSelection)
-                .style(style::SelectionCheckBox::Disabled(settings.theme.palette));
+                .style(style::CheckBox::PackageDisabled);
 
             action_btn = button(
                 text(action_text)
@@ -106,26 +106,26 @@ impl PackageRow {
             );
         }
 
-        row()
-            .push(
-                button(
-                    row()
-                        .align_items(Alignment::Center)
-                        .push(selection_checkbox)
-                        .push(text(&self.name).width(Length::FillPortion(8)))
-                        .push(action_btn.style(button_style)),
-                )
-                .padding(8)
-                .style(if self.current {
-                    style::PackageRow::Current(settings.theme.palette)
-                } else {
-                    style::PackageRow::Normal(settings.theme.palette)
-                })
-                .width(Length::Fill)
-                .on_press(Message::PackagePressed),
+        row![
+            button(
+                row![
+                    selection_checkbox,
+                    text(&self.name).width(Length::FillPortion(8)),
+                    action_btn.style(button_style)
+                ]
+                .align_items(Alignment::Center)
             )
-            .push(Space::with_width(Length::Units(15)))
-            .align_items(Alignment::Center)
-            .into()
+            .padding(8)
+            .style(if self.current {
+                style::Button::SelectedPackage
+            } else {
+                style::Button::NormalPackage
+            })
+            .width(Length::Fill)
+            .on_press(Message::PackagePressed),
+            Space::with_width(Length::Units(15))
+        ]
+        .align_items(Alignment::Center)
+        .into()
     }
 }


### PR DESCRIPTION
- Remove custom code for theming: UAD now uses the new Iced styling API
- All the code for initializing UAD (download debloat lists, fetch connected devices etc...) is now a lot more streamlined
- Other miscellaneous code improvement
- Replace `row()` and `column()` functions by the new Iced vector-like helper functions (`row![]`, `column![]`)
- Move navigation menu GUI code in a dedicated file
- Rework the way UAD uses events for async code

In a nutshell, the codebase is now a lot easier to maintain! 

**Note**: UAD is now temporarily based on my fork of Iced until https://github.com/iced-rs/iced/pull/1425 is merged upstream. 