### PR TITLE
pkg: Add 'Samsung Services' to list

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20054,7 +20054,7 @@
   {
     "id": "com.samsung.android.setupindiaservicestnc",
     "list": "Oem",
-    "description": "Samsung Services\nResponsible for the persistent notification after every system update if you don't agree to data collection.",
+    "description": "Samsung Services\nResponsible for the persistent notification after every system update if you don't agree to data collection.\nThe only way to dismiss it without agreeing to anything is to click the small text and uncheck all the items in a list. Then the 'Agree' button becomes a 'Skip' button. Removing this package doesn't have any known side effects.",
     "dependencies": null,
     "neededBy": null,
     "labels": null,

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20050,5 +20050,14 @@
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.setupindiaservicestnc",
+    "list": "Oem",
+    "description": "Samsung Services\nResponsible for the persistent notification after every system update if you don't agree to data collection.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
   }
 ]


### PR DESCRIPTION
Adds `com.samsung.android.setupindiaservicestnc` to the list. It shows a persistent notification after every system update and asks for agreement to share data with no obvious way to skip it. The only way to dismiss it without agreeing to anything is to click the small text and uncheck all the items in a list. Then the 'Agree' button becomes a 'Skip' button. Uninstalling it doesn't seem to cause any issues.