### PR TITLE
pkg: add 18 new Unihertz apps (+ more documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ NB : System apps cannot really be uninstalled without root (see the [FAQ](https:
 * [X] Motorola
 * [X] Nokia
 * [X] OnePlus
-* [X] Oppo  
+* [X] Oppo
 * [X] Samsung
 * [X] Sony
 * [X] Tecno
 * [ ] TCL
+* [X] Unihertz
 * [ ] Wiko
 * [X] Xiaomi
 * [ ] ZTE

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -8154,15 +8154,6 @@
     "removal": "Unsafe"
   },
   {
-    "id": "com.android.fmradio",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
     "id": "com.mediatek.gba",
     "list": "Pending",
     "description": "",
@@ -8206,15 +8197,6 @@
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
-  },
-  {
-    "id": "com.mediatek.simprocessor",
-    "list": "Pending",
-    "description": "",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Recommended"
   },
   {
     "id": "com.mediatek.mms.appservice",
@@ -8434,18 +8416,18 @@
   },
   {
     "id": "com.android.cellbroadcastreceiver.basiccolorblack.overlay",
-    "list": "Pending",
-    "description": "Dark theme overlay for cellbroadcastreceiver?",
-    "dependencies": null,
+    "list": "Aosp",
+    "description": "Dark theme overlay for com.android.cellbroadcastreceiver",
+    "dependencies": ["com.android.cellbroadcastreceiver"],
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
   },
   {
     "id": "com.android.cellbroadcastreceiver.basiccolorwhite.overlay",
-    "list": "Pending",
-    "description": "Light theme overlay for cellbroadcastreceiver?",
-    "dependencies": null,
+    "list": "Aosp",
+    "description": "Light theme overlay for com.android.cellbroadcastreceiver",
+    "dependencies": ["com.android.cellbroadcastreceiver"],
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
@@ -8453,7 +8435,7 @@
   {
     "id": "com.android.cellbroadcastreceiver.overlay.common",
     "list": "Aosp",
-    "description": "com.android.cellbroadcastreceiver Theme pack\nGuessing it's a pack of themes for the cellbroadcastreceiver, based on the name.",
+    "description": "com.android.cellbroadcastreceiver Theme pack",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -9759,17 +9741,17 @@
     "id": "com.google.android.cellbroadcastreceiver",
     "list": "Aosp",
     "description": "Wireless emergency alerts\nCell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts.\nRuns at boot and is also triggered after exiting airplane mode.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know\nhttps://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver/+/refs/heads/master/src/com/android/cellbroadcastreceiver",
-    "dependencies": null,
+    "dependencies": ["com.google.android.cellbroadcastservice"],
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
   },
   {
     "id": "com.google.android.cellbroadcastservice",
-    "list": "Pending",
+    "list": "Aosp",
     "description": "Cell broadcast is designed to deliver messages to multiple users in an area.\nThis is notably used by ISP to send Emergency/Government alerts.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast\nhttps://www.androidcentral.com/amber-alerts-and-android-what-you-need-know",
     "dependencies": null,
-    "neededBy": null,
+    "neededBy": ["com.google.android.cellbroadcastreceiver"],
     "labels": null,
     "removal": "Expert"
   },
@@ -9831,15 +9813,6 @@
     "id": "com.google.android.overlay.gmsconfig.photos",
     "list": "Pending",
     "description": "Android System Theme pack\nGuessing it's a pack of overlay themes for Android System or Google Play Services based on the name.",
-    "dependencies": null,
-    "neededBy": null,
-    "labels": null,
-    "removal": "Expert"
-  },
-  {
-    "id": "com.google.android.overlay.modules.cellbroadcastreceiver",
-    "list": "Pending",
-    "description": "",
     "dependencies": null,
     "neededBy": null,
     "labels": null,
@@ -12754,9 +12727,9 @@
   },
   {
     "id": "com.android.cellbroadcastreceiver.overlay.base.s600ww",
-    "list": "Pending",
-    "description": "Theme overlay for cellbroadcastreceiver?",
-    "dependencies": null,
+    "list": "Oem",
+    "description": "Nokia theme overlay for com.android.cellbroadcastreceiver",
+    "dependencies": ["com.android.cellbroadcastreceiver"],
     "neededBy": null,
     "labels": null,
     "removal": "Expert"
@@ -20517,7 +20490,7 @@
     "neededBy": null,
     "labels": null,
     "removal": "Advanced"
-  }
+  },
   {
     "id": "com.tiqiaa.remote",
     "list": "Misc",
@@ -20697,5 +20670,14 @@
     "neededBy": null,
     "labels": null,
     "removal": "Recommended"
+  },
+  {
+    "id": "com.google.android.overlay.modules.cellbroadcastreceiver",
+    "list": "Google",
+    "description": "Overlay (theme/notification) module for com.google.android.cellbroadcastreceiver",
+    "dependencies": ["com.google.android.cellbroadcastreceiver"],
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
   }
 ]

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20518,4 +20518,184 @@
     "labels": null,
     "removal": "Advanced"
   }
+  {
+    "id": "com.tiqiaa.remote",
+    "list": "Misc",
+    "description": "ZazaRemote (https://play.google.com/store/apps/details?id=com.tiqiaa.remote)\nA Universal infrared control app full of trackers and with unecessary permissions.\n\nPithus analysis: https://beta.pithus.org/report/93eed47a45c00998f2111907afc26b5697aaf7fb19c0efb6b42d46addf0e297c",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.agui.toolbox",
+    "list": "Misc",
+    "description": "Toolbox\n contains a bunch a small utilites, most have there own APP but are only accessible from the Toolbox UI\nincluded; Noise test, Compass, Flashlight, Bubble Level, Picture Hanging, Heart rate, Measure height,\n Magnifier,Alarm, Plumb Bob, Protractor, Speedometer & a Pedometer.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.agui.usbcamera",
+    "list": "Oem",
+    "description": "Toolbox > \"USB Camera\" Only usefull if you want to use a USB Camera\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.agui.game",
+    "list": "Oem",
+    "description": "Game mode\nBlocks calls & notifications when selected APP's are open\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.agui.newsos",
+    "list": "Oem",
+    "description": "SOS\nNotify emergency contacts. When triggered, will also put the phone in a low comsumption mode\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.agui.nfc",
+    "list": "Oem",
+    "description": "NFC card emulation: simulates various types of unencrypted entrance cards.\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.android.fmradio",
+    "list": "Aosp",
+    "description": "FM Radio\n Plug in Head phones & listen to the Radio!\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.haoba.btsmart",
+    "list": "Misc",
+    "description": "Agui Unibuds\nIot stuff. May only be needed if you use Uniherts Ear Buds (Unibuds).",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.scanning.agold.agoldscanning",
+    "list": "Oem",
+    "description": "\"Scan\" Settings > intelligent assistant: Scan. QR code & Bar code scanner.\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.agui.studentmodel",
+    "list": "Oem",
+    "description": "Student Mode\nLocks down your phone to reduce distractions\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.mediatek.simprocessor",
+    "list": "Misc",
+    "description": "This control and import contacts saved on a SIM card. Not needed if you don't store your contacts on the SIM card\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.mediatek.ims.pco",
+    "list": "Misc",
+    "description": "Protocol Configuration Options service for IMS\nIMS(Ip Multimedia Subsystem) is an open industry standard for voice and multimedia communications over packet-based IP networks (VoLTE/VoIP/Wifi calling). This package enable automatic configuration pushed by your carrier. You could possibly remove it if you don't use IMS.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.agui.update",
+    "list": "Oem",
+    "description": "\"Wireless Update\" Settings > About Phone : Sytem update.\nRemoving will prevent Automatic Wireless Updates\n",
+    "dependencies": null,
+    "neededBy": ["com.agui.update.overlay"],
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.agui.update.overlay",
+    "list": "Oem",
+    "description": "Overlay for com.agui.update. Overlay are usually themes.\n",
+    "dependencies": ["com.agui.update"],
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.agui.screenshot",
+    "list": "Oem",
+    "description": "Screenshot\nScreenshot utility triggered when double tapping the Red Button\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.agui.batterystatsdumper",
+    "list": "Oem",
+    "description": "Battery Stats Dumper\nLets you check and clear battery usage statistics.\nEnter *#*#010#*#* in the dial pad to access this hidden menu.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.agui.app.imei",
+    "list": "Oem",
+    "description": "IMEI Tool: Change MEID's & IMEI's of both SIM's\nEnter *#*#08#*#* in the dial pad to access\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.agui.appblock",
+    "list": "Oem",
+    "description": "App blocker\nSettings > Intelligent assistance: App blocker\n Unihertz power management service killing background apps to improve battery performance.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Expert"
+  },
+  {
+    "id": "com.agui.providers.pedometer",
+    "list": "Oem",
+    "description": "Toolbox > \"Pedometer\" Pedometer/step counter.\nBecause of a feature that integrates with the lock sceen the System UI crashes when removed.",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Unsafe"
+  },
+  {
+    "id": "com.agui.app.memtester",
+    "list": "Oem",
+    "description": "Memory tester\nHidden test menu. Used in diagnostics, normally invoked by MMI(Man-Machine Interface) Codes\n",
+    "dependencies": null,
+    "neededBy": null,
+    "labels": null,
+    "removal": "Recommended"
+  }
 ]


### PR DESCRIPTION
New or changed packages :
- Unsafe: 1
- Expert: 5
- Advanced: 4
- Recommended: 10

This pull request documents `com.android.fmradio` and `com.mediatek.simprocessor` and improve documentation of several cellbroadcastreceiver related packages.

Co-authored-by:  VeH-c <30818998+VeH-c@users.noreply.github.com>

--------------------

@VeH-c 
I opened this pull request in favor of #311 because I can't modify it.

I cherry picked your change for `com.google.android.webview` to add the warning on the others webview apps in 01c2371

I added more documentation for some other apps