### PR TITLE
feat: backup/restore the state of a device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ and `Removed`.
 
 ## [0.6] - Unreleased
 
+**WARNING: Settings specification has changed. Previous user settings will be erased**.
+
 ### Added
-- [[#374](https://github.com/0x192/universal-android-debloater/pull/374)] Device-specific persistent configuration. Some settings are now device-specific which means you can maintain different settings across several devices. 
-**Note: Settings specification has changed. Previous user settings will be erased**.
+- [[#374](https://github.com/0x192/universal-android-debloater/pull/374)] **Device-specific persistent configuration:** Some settings are now device-specific which means you can maintain different settings across several devices.
+
+- [[#447](https://github.com/0x192/universal-android-debloater/pull/447)] **Backup/Restore the state of a device:** Quick and easy way to save the state of all the system apps on a device and restore it.
 
 ### Changed
 - [[#374](https://github.com/0x192/universal-android-debloater/pull/374)] All settings are now persistent.
+
+### Removed
+- The `Export current selection` button and the unintuitive auto import selection (see https://github.com/0x192/universal-android-debloater/issues/192) have been replaced by the new backup/restore system.
 
 ## [0.5.1] - 2022-07-03
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,4 +1,5 @@
-use crate::core::sync::get_android_sdk;
+use crate::core::sync::{get_android_sdk, User};
+use crate::core::utils::DisplayablePath;
 use crate::gui::views::settings::Settings;
 use crate::CONFIG_DIR;
 use serde::{Deserialize, Serialize};
@@ -19,19 +20,31 @@ pub struct GeneralSettings {
     pub expert_mode: bool,
 }
 
+#[derive(Default, Debug, Clone)]
+pub struct BackupSettings {
+    pub backups: Vec<DisplayablePath>,
+    pub selected: Option<DisplayablePath>,
+    pub users: Vec<User>,
+    pub selected_user: Option<User>,
+    pub backup_state: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeviceSettings {
     pub device_id: String,
     pub disable_mode: bool,
     pub multi_user_mode: bool,
+    #[serde(skip)]
+    pub backup: BackupSettings,
 }
 
 impl Default for DeviceSettings {
     fn default() -> Self {
         Self {
-            device_id: "".to_string(),
+            device_id: String::new(),
             multi_user_mode: get_android_sdk() > 21,
             disable_mode: false,
+            backup: BackupSettings::default(),
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod save;
 pub mod sync;
 pub mod theme;
 pub mod uad_lists;

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -58,7 +58,8 @@ pub async fn backup_phone(
                 return Err(e.to_string());
             };
 
-            let backup_filename = format!("{}.json", chrono::Local::now().format("%Y-%m-%d-%H-%M"));
+            let backup_filename =
+                format!("{}.json", chrono::Local::now().format("%Y-%m-%d_%H-%M-%S"));
 
             match fs::write(backup_path.join(backup_filename), json) {
                 Ok(_) => Ok(()),

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -1,0 +1,170 @@
+use crate::core::config::DeviceSettings;
+use crate::core::sync::{apply_pkg_state_commands, CorePackage, Phone, User};
+use crate::core::utils::DisplayablePath;
+use crate::gui::widgets::package_row::PackageRow;
+use crate::CACHE_DIR;
+use serde::{Deserialize, Serialize};
+use static_init::dynamic;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[dynamic]
+pub static BACKUP_DIR: PathBuf = CACHE_DIR.join("backups");
+
+#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+struct PhoneBackup {
+    device_id: String,
+    users: Vec<UserBackup>,
+}
+
+#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+struct UserBackup {
+    id: u16,
+    packages: Vec<CorePackage>,
+}
+
+// Backup all `Uninstalled` and `Disabled` packages
+pub async fn backup_phone(
+    users: Vec<User>,
+    device_id: String,
+    phone_packages: Vec<Vec<PackageRow>>,
+) -> Result<(), String> {
+    let mut backup = PhoneBackup {
+        device_id: device_id.clone(),
+        ..PhoneBackup::default()
+    };
+
+    for u in users {
+        let mut user_backup = UserBackup {
+            id: u.id,
+            ..UserBackup::default()
+        };
+
+        for p in phone_packages[u.index].clone() {
+            user_backup.packages.push(CorePackage {
+                name: p.name.clone(),
+                state: p.state,
+            })
+        }
+        backup.users.push(user_backup);
+    }
+
+    match serde_json::to_string_pretty(&backup) {
+        Ok(json) => {
+            let backup_path = &*BACKUP_DIR.join(device_id);
+
+            if let Err(e) = fs::create_dir_all(backup_path) {
+                error!("BACKUP: could not create backup dir: {}", e);
+                return Err(e.to_string());
+            };
+
+            let backup_filename = format!("{}.json", chrono::Local::now().format("%Y-%m-%d-%H-%M"));
+
+            match fs::write(backup_path.join(backup_filename), json) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => {
+            error!("[BACKUP]: {}", err);
+            Err(err.to_string())
+        }
+    }
+}
+
+pub fn list_available_backups(dir: &Path) -> Vec<DisplayablePath> {
+    match fs::read_dir(dir) {
+        Ok(files) => files
+            .filter_map(|e| e.ok())
+            .map(|e| DisplayablePath { path: e.path() })
+            .collect::<Vec<_>>(),
+        Err(_) => vec![],
+    }
+}
+
+pub fn list_available_backup_user(backup: DisplayablePath) -> Vec<User> {
+    match fs::read_to_string(backup.path) {
+        Ok(data) => {
+            let phone_backup: PhoneBackup =
+                serde_json::from_str(&data).expect("Unable to parse backup file");
+
+            let mut users = vec![];
+            for u in phone_backup.users {
+                users.push(User { id: u.id, index: 0 });
+            }
+            users
+        }
+        Err(e) => {
+            error!("[BACKUP]: Selected backup file not found: {}", e);
+            vec![]
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BackupPackage {
+    pub index: usize,
+    pub commands: Vec<String>,
+}
+
+pub fn restore_backup(
+    selected_device: &Phone,
+    packages: &[Vec<PackageRow>],
+    settings: &DeviceSettings,
+) -> Result<Vec<BackupPackage>, String> {
+    match fs::read_to_string(settings.backup.selected.as_ref().unwrap().path.clone()) {
+        Ok(data) => {
+            let phone_backup: PhoneBackup =
+                serde_json::from_str(&data).expect("Unable to parse backup file");
+
+            let mut commands = vec![];
+            for u in phone_backup.users {
+                if u.id != settings.backup.selected_user.unwrap().id {
+                    continue;
+                }
+
+                let mut _index = 0;
+                match selected_device.user_list.iter().find(|x| x.id == u.id) {
+                    Some(i) => _index = i.index,
+                    None => return Err(format!("user {} doesn't exist", u.id)),
+                };
+
+                for (i, backup_package) in u.packages.iter().enumerate() {
+                    let package: CorePackage;
+                    match packages[_index]
+                        .iter()
+                        .find(|x| x.name == backup_package.name)
+                    {
+                        Some(p) => package = p.into(),
+                        None => {
+                            return Err(format!(
+                                "{} not found for user {}",
+                                backup_package.name, u.id
+                            ))
+                        }
+                    }
+                    let p_commands = apply_pkg_state_commands(
+                        &package,
+                        &backup_package.state,
+                        &settings.backup.selected_user.unwrap(),
+                        selected_device,
+                    );
+                    if !p_commands.is_empty() {
+                        commands.push(BackupPackage {
+                            index: i,
+                            commands: p_commands,
+                        });
+                    }
+                }
+            }
+            if !commands.is_empty() {
+                commands.push(BackupPackage {
+                    index: 0,
+                    commands: vec![],
+                });
+            }
+            Ok(commands)
+        }
+        Err(e) => Err("[BACKUP]: ".to_owned() + &e.to_string()),
+    }
+}

--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -1,7 +1,7 @@
 use crate::core::utils::{format_diff_time_from_now, last_modified_date};
 use crate::CACHE_DIR;
 use retry::{delay::Fixed, retry, OperationResult};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 use std::fs;
@@ -94,7 +94,7 @@ impl std::fmt::Display for UadList {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PackageState {
     All,
     Enabled,

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,6 +1,4 @@
-use crate::core::sync::{
-    adb_shell_command, hashset_system_packages, list_all_system_packages, User,
-};
+use crate::core::sync::{hashset_system_packages, list_all_system_packages, User};
 use crate::core::theme::Theme;
 use crate::core::uad_lists::{Package, PackageState, Removal, UadList};
 use crate::gui::views::list::Selection;
@@ -8,10 +6,9 @@ use crate::gui::widgets::package_row::PackageRow;
 use chrono::offset::Utc;
 use chrono::DateTime;
 use std::collections::HashMap;
-use std::fs;
-use std::io::{self, prelude::*, BufReader};
 use std::path::PathBuf;
 use std::process::Command;
+use std::{fmt, fs};
 
 pub fn fetch_packages(
     uad_lists: &HashMap<String, Package>,
@@ -82,44 +79,6 @@ pub fn update_selection_count(selection: &mut Selection, p_state: PackageState, 
     };
 }
 
-pub async fn export_selection(packages: Vec<PackageRow>) -> Result<bool, String> {
-    let selected = packages
-        .iter()
-        .filter(|p| p.selected)
-        .map(|p| p.name.clone())
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    match fs::write("uad_exported_selection.txt", selected) {
-        Ok(_) => Ok(true),
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-#[allow(clippy::needless_collect)] // false positive: https://github.com/rust-lang/rust-clippy/issues/6164
-pub fn import_selection(packages: &mut [PackageRow], selection: &mut Selection) -> io::Result<()> {
-    let file = fs::File::open("uad_exported_selection.txt")?;
-    let reader = BufReader::new(file);
-    let imported_selection: Vec<String> = reader
-        .lines()
-        .map(|l| l.expect("Could not parse line"))
-        .collect();
-
-    *selection = Selection::default(); // should already be empty normally
-
-    for (i, p) in packages.iter_mut().enumerate() {
-        if imported_selection.contains(&p.name) {
-            p.selected = true;
-            selection.selected_packages.push(i);
-            update_selection_count(selection, p.state, true);
-        } else {
-            p.selected = false;
-        }
-    }
-
-    Ok(())
-}
-
 pub fn string_to_theme(theme: String) -> Theme {
     match theme.as_str() {
         "Dark" => Theme::Dark,
@@ -180,27 +139,26 @@ pub fn format_diff_time_from_now(date: DateTime<Utc>) -> String {
     }
 }
 
-pub async fn perform_adb_commands(action: String, i: usize, label: String) -> Result<usize, ()> {
-    match adb_shell_command(true, &action) {
-        Ok(o) => {
-            // On old devices, adb commands can return the '0' exit code even if there
-            // is an error. On Android 4.4, ADB doesn't check if the package exists.
-            // It does not return any error if you try to `pm block` a non-existent package.
-            // Some commands are even killed by ADB before finishing and UAD can't catch
-            // the output.
-            if ["Error", "Failure"].iter().any(|&e| o.contains(e)) {
-                error!("[{}] {} -> {}", label, action, o);
-                Err(())
-            } else {
-                info!("[{}] {} -> {}", label, action, o);
-                Ok(i)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayablePath {
+    pub path: PathBuf,
+}
+
+impl fmt::Display for DisplayablePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let stem = match self.path.file_stem() {
+            Some(p) => match p.to_os_string().into_string() {
+                Ok(stem) => stem,
+                Err(e) => {
+                    error!("[PATH ENCODING]: {:?}", e);
+                    "[PATH ENCODING ERROR]".to_string()
+                }
+            },
+            None => {
+                error!("[PATH STEM]: No file stem found");
+                "[File steam not found]".to_string()
             }
-        }
-        Err(err) => {
-            if !err.contains("[not installed for") {
-                error!("[{}] {} -> {}", label, action, err);
-            }
-            Err(())
-        }
+        };
+        write!(f, "{}", stem)
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,11 +2,11 @@ pub mod style;
 pub mod views;
 pub mod widgets;
 
-use crate::core::sync::{get_devices_list, Phone};
+use crate::core::sync::{get_devices_list, perform_adb_commands, CommandType, Phone};
 use crate::core::theme::Theme;
 use crate::core::uad_lists::UadListState;
 use crate::core::update::{get_latest_release, Release, SelfUpdateState, SelfUpdateStatus};
-use crate::core::utils::{perform_adb_commands, string_to_theme};
+use crate::core::utils::string_to_theme;
 
 use views::about::{About as AboutView, Message as AboutMessage};
 use views::list::{List as AppsView, LoadingState as ListLoadingState, Message as AppsMessage};
@@ -43,6 +43,7 @@ pub struct UadGui {
     devices_list: Vec<Phone>,
     selected_device: Option<Phone>, // index of devices_list
     update_state: UpdateState,
+    nb_running_async_adb_commands: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -123,15 +124,15 @@ impl Application for UadGui {
                 Command::none()
             }
             Message::RefreshButtonPressed => {
-                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                self.apps_view.loading_state = ListLoadingState::FindingPhones("".to_string());
                 Command::perform(get_devices_list(), Message::LoadDevices)
             }
             Message::RebootButtonPressed => {
-                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                self.apps_view.loading_state = ListLoadingState::FindingPhones("".to_string());
                 self.selected_device = None;
                 self.devices_list = vec![];
                 Command::perform(
-                    perform_adb_commands("reboot".to_string(), 0, "ADB".to_string()),
+                    perform_adb_commands("reboot".to_string(), CommandType::Shell),
                     |_| Message::Nothing,
                 )
             }
@@ -145,9 +146,29 @@ impl Application for UadGui {
                 )
                 .map(Message::AppsAction),
             Message::SettingsAction(msg) => {
+                if let SettingsMessage::RestoringDevice(ref output) = msg {
+                    self.nb_running_async_adb_commands -= 1;
+                    self.view = View::List;
+                    self.apps_view.update(
+                        &mut self.settings_view,
+                        &mut self.selected_device.clone().unwrap_or_default(),
+                        &mut self.update_state.uad_list,
+                        AppsMessage::RestoringDevice(output.clone()),
+                    );
+
+                    if self.nb_running_async_adb_commands == 0 {
+                        return self.update(Message::RefreshButtonPressed);
+                    }
+                }
+
                 self.settings_view
-                    .update(&self.selected_device.clone().unwrap_or_default(), msg);
-                Command::none()
+                    .update(
+                        &self.selected_device.clone().unwrap_or_default(),
+                        &self.apps_view.phone_packages,
+                        &mut self.nb_running_async_adb_commands,
+                        msg,
+                    )
+                    .map(Message::SettingsAction)
             }
             Message::AboutAction(msg) => {
                 self.about_view.update(msg.clone());
@@ -155,14 +176,16 @@ impl Application for UadGui {
                 match msg {
                     AboutMessage::UpdateUadLists => {
                         self.update_state.uad_list = UadListState::Downloading;
-                        self.apps_view.loading_state = ListLoadingState::DownloadingList;
+                        self.apps_view.loading_state =
+                            ListLoadingState::DownloadingList("".to_string());
                         self.update(Message::AppsAction(AppsMessage::LoadUadList(true)))
                     }
                     AboutMessage::DoSelfUpdate => {
                         #[cfg(feature = "self-update")]
                         if self.update_state.self_update.latest_release.is_some() {
                             self.update_state.self_update.status = SelfUpdateStatus::Updating;
-                            self.apps_view.loading_state = ListLoadingState::_UpdatingUad;
+                            self.apps_view.loading_state =
+                                ListLoadingState::_UpdatingUad("".to_string());
                             let bin_name = bin_name().to_owned();
                             let release = self
                                 .update_state
@@ -194,7 +217,7 @@ impl Application for UadGui {
                     s_device.android_sdk, s_device.model
                 );
                 info!("{:-^65}", "-");
-                self.apps_view.loading_state = ListLoadingState::FindingPhones;
+                self.apps_view.loading_state = ListLoadingState::FindingPhones("".to_string());
                 self.update(Message::SettingsAction(SettingsMessage::LoadDeviceSettings));
                 self.update(Message::AppsAction(AppsMessage::LoadPhonePackages((
                     self.apps_view.uad_lists.clone(),

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -152,6 +152,7 @@ impl button::StyleSheet for Theme {
         match style {
             Button::RestorePackage => disabled_appearance(p.normal.primary, Some(p.bright.primary)),
             Button::UninstallPackage => disabled_appearance(p.bright.error, None),
+            Button::Primary => disabled_appearance(p.normal.primary, Some(p.bright.primary)),
             _ => button::Appearance { ..active },
         }
     }

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -324,10 +324,16 @@ impl Settings {
             }
         };
 
-        let locate_backup_btn = button("Open backup directory")
-            .on_press(Message::UrlPressed(BACKUP_DIR.join(phone.adb_id.clone())))
-            .padding(5)
-            .style(style::Button::Primary);
+        let locate_backup_btn = if self.device.backup.backups.is_empty() {
+            button("Open backup directory")
+                .padding(5)
+                .style(style::Button::Primary)
+        } else {
+            button("Open backup directory")
+                .on_press(Message::UrlPressed(BACKUP_DIR.join(phone.adb_id.clone())))
+                .padding(5)
+                .style(style::Button::Primary)
+        };
 
         let backup_row = row![
             backup_btn,

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -130,7 +130,7 @@ impl Settings {
                 Message::DeviceBackedUp,
             ),
             Message::DeviceBackedUp(_) => {
-                error!("[BACKUP] Backup done");
+                info!("[BACKUP] Backup successfully created");
                 self.device.backup.backups =
                     list_available_backups(&BACKUP_DIR.join(phone.adb_id.clone()));
                 self.device.backup.selected = self.device.backup.backups.first().cloned();

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -1,11 +1,16 @@
-use crate::core::config::{Config, DeviceSettings, GeneralSettings};
-use crate::core::sync::Phone;
+use crate::core::config::{BackupSettings, Config, DeviceSettings, GeneralSettings};
+use crate::core::save::{
+    backup_phone, list_available_backup_user, list_available_backups, restore_backup, BACKUP_DIR,
+};
+use crate::core::sync::{perform_adb_commands, CommandType, Phone};
 use crate::core::theme::Theme;
-use crate::core::utils::{open_url, string_to_theme};
+use crate::core::utils::{open_url, string_to_theme, DisplayablePath};
 use crate::gui::style;
+use crate::gui::views::list::PackageInfo;
+use crate::gui::widgets::package_row::PackageRow;
 
-use iced::widget::{button, checkbox, column, container, radio, row, text, Space};
-use iced::{Element, Length, Renderer};
+use iced::widget::{button, checkbox, column, container, pick_list, radio, row, text, Space};
+use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -31,15 +36,27 @@ pub enum Message {
     MultiUserMode(bool),
     ApplyTheme(Theme),
     UrlPressed(PathBuf),
+    BackupSelected(DisplayablePath),
+    BackupDevice,
+    RestoreDevice,
+    RestoringDevice(Result<CommandType, ()>),
+    DeviceBackedUp(Result<(), String>),
 }
 
 impl Settings {
-    pub fn update(&mut self, phone: &Phone, msg: Message) {
+    pub fn update(
+        &mut self,
+        phone: &Phone,
+        packages: &[Vec<PackageRow>],
+        nb_running_async_adb_commands: &mut u32,
+        msg: Message,
+    ) -> Command<Message> {
         match msg {
             Message::ExpertMode(toggled) => {
                 self.general.expert_mode = toggled;
                 debug!("Config change: {:?}", self);
                 Config::save_changes(self, &phone.adb_id);
+                Command::none()
             }
             Message::DisableMode(toggled) => {
                 if phone.android_sdk >= 23 {
@@ -47,36 +64,116 @@ impl Settings {
                     debug!("Config change: {:?}", self);
                     Config::save_changes(self, &phone.adb_id);
                 }
+                Command::none()
             }
             Message::MultiUserMode(toggled) => {
                 self.device.multi_user_mode = toggled;
                 debug!("Config change: {:?}", self);
                 Config::save_changes(self, &phone.adb_id);
+                Command::none()
             }
             Message::ApplyTheme(theme) => {
                 self.general.theme = theme.to_string();
                 debug!("Config change: {:?}", self);
                 Config::save_changes(self, &phone.adb_id);
+                Command::none()
             }
             Message::UrlPressed(url) => {
                 open_url(url);
+                Command::none()
             }
             Message::LoadDeviceSettings => {
+                let backups = list_available_backups(&BACKUP_DIR.join(phone.adb_id.clone()));
                 match Config::load_configuration_file()
                     .devices
                     .iter()
                     .find(|d| d.device_id == phone.adb_id)
                 {
-                    Some(device) => self.device = device.clone(),
+                    Some(device) => {
+                        self.device = device.clone();
+                        self.device.backup = BackupSettings {
+                            backups: backups.clone(),
+                            selected: backups.first().cloned(),
+                            users: phone.user_list.clone(),
+                            selected_user: phone.user_list.first().copied(),
+                            backup_state: "".to_string(),
+                        };
+                    }
                     None => {
                         self.device = DeviceSettings {
                             device_id: phone.adb_id.clone(),
                             multi_user_mode: phone.android_sdk > 21,
                             disable_mode: false,
+                            backup: BackupSettings {
+                                backups: backups.clone(),
+                                selected: backups.first().cloned(),
+                                users: phone.user_list.clone(),
+                                selected_user: phone.user_list.first().copied(),
+                                backup_state: "".to_string(),
+                            },
                         }
                     }
                 };
+                Command::none()
             }
+            Message::BackupSelected(d_path) => {
+                self.device.backup.selected = Some(d_path.clone());
+                self.device.backup.users = list_available_backup_user(d_path);
+                Command::none()
+            }
+            Message::BackupDevice => Command::perform(
+                backup_phone(
+                    phone.user_list.clone(),
+                    self.device.device_id.clone(),
+                    packages.to_vec(),
+                ),
+                Message::DeviceBackedUp,
+            ),
+            Message::DeviceBackedUp(_) => {
+                error!("[BACKUP] Backup done");
+                self.device.backup.backups =
+                    list_available_backups(&BACKUP_DIR.join(phone.adb_id.clone()));
+                self.device.backup.selected = self.device.backup.backups.first().cloned();
+                Command::none()
+            }
+            Message::RestoreDevice => match restore_backup(phone, packages, &self.device) {
+                Ok(r_packages) => {
+                    let mut commands = vec![];
+                    *nb_running_async_adb_commands = 0;
+                    for p in &r_packages {
+                        let p_info = PackageInfo {
+                            index: p.index,
+                            removal: "RESTORE".to_string(),
+                        };
+                        for command in p.commands.clone() {
+                            *nb_running_async_adb_commands += 1;
+                            commands.push(Command::perform(
+                                perform_adb_commands(
+                                    command,
+                                    CommandType::PackageManager(p_info.clone()),
+                                ),
+                                Message::RestoringDevice,
+                            ));
+                        }
+                    }
+                    if r_packages.is_empty() {
+                        self.device.backup.backup_state =
+                            "Device state is already restored".to_string();
+                    }
+                    info!(
+                        "[RESTORE] Restoring backup {}",
+                        self.device.backup.selected.as_ref().unwrap()
+                    );
+                    Command::batch(commands)
+                }
+                Err(e) => {
+                    self.device.backup.backup_state = format!("ERROR: {}", e);
+                    error!("[BACKUP] {}", e);
+                    Command::none()
+                }
+            },
+            // Trigger an action in mod.rs (Message::SettingsAction(msg))
+            Message::RestoringDevice(_) => Command::none(),
         }
     }
 
@@ -112,11 +209,19 @@ impl Settings {
                 .style(style::Text::Commentary)
                 .size(15);
 
+        let general_ctn = container(column![expert_mode_checkbox, expert_mode_descr].spacing(10))
+            .padding(10)
+            .width(Length::Fill)
+            .height(Length::Shrink)
+            .style(style::Container::Frame);
+
         let warning_ctn = container(
             row![
                 text("The following settings only affect the currently selected device :")
                     .style(style::Text::Danger),
-                text(phone.model.to_owned())
+                text(phone.model.to_owned()),
+                Space::new(Length::Fill, Length::Shrink),
+                text(phone.adb_id.clone()).style(style::Text::Commentary)
             ]
             .spacing(7),
         )
@@ -179,12 +284,6 @@ impl Settings {
             .width(Length::Fill)
         };
 
-        let general_ctn = container(column![expert_mode_checkbox, expert_mode_descr].spacing(10))
-            .padding(10)
-            .width(Length::Fill)
-            .height(Length::Shrink)
-            .style(style::Container::Frame);
-
         let device_specific_ctn = container(
             column![
                 multi_user_mode_checkbox,
@@ -199,17 +298,102 @@ impl Settings {
         .height(Length::Shrink)
         .style(style::Container::Frame);
 
-        let content = column![
-            text("Theme").size(25),
-            theme_ctn,
-            text("General").size(25),
-            general_ctn,
-            text("Current device").size(25),
-            warning_ctn,
-            device_specific_ctn,
+        let backup_pick_list = pick_list(
+            self.device.backup.backups.clone(),
+            self.device.backup.selected.clone(),
+            Message::BackupSelected,
+        )
+        .padding(6);
+
+        let backup_btn = button(text("Backup").horizontal_alignment(alignment::Horizontal::Center))
+            .padding(5)
+            .on_press(Message::BackupDevice)
+            .style(style::Button::Primary)
+            .width(Length::Units(77));
+
+        let restore_btn = |enabled| {
+            if enabled {
+                button(text("Restore").horizontal_alignment(alignment::Horizontal::Center))
+                    .padding(5)
+                    .on_press(Message::RestoreDevice)
+                    .width(Length::Units(77))
+            } else {
+                button(text("No backup").horizontal_alignment(alignment::Horizontal::Center))
+                    .padding(5)
+                    .width(Length::Units(77))
+            }
+        };
+
+        let locate_backup_btn = button("Open backup directory")
+            .on_press(Message::UrlPressed(BACKUP_DIR.join(phone.adb_id.clone())))
+            .padding(5)
+            .style(style::Button::Primary);
+
+        let backup_row = row![
+            backup_btn,
+            "Backup the current state of the phone",
+            Space::new(Length::Fill, Length::Shrink),
+            locate_backup_btn,
         ]
-        .width(Length::Fill)
-        .spacing(20);
+        .spacing(10)
+        .align_items(Alignment::Center);
+
+        let restore_row = if self.device.backup.backups.is_empty() {
+            row![restore_btn(false), "Restore the state of the device",]
+                .spacing(10)
+                .align_items(Alignment::Center)
+        } else {
+            row![
+                restore_btn(true),
+                "Restore the state of the device",
+                Space::new(Length::Fill, Length::Shrink),
+                text(self.device.backup.backup_state.clone()).style(style::Text::Danger),
+                backup_pick_list,
+            ]
+            .spacing(10)
+            .align_items(Alignment::Center)
+        };
+
+        let backup_restore_ctn = container(column![backup_row, restore_row].spacing(10))
+            .padding(10)
+            .width(Length::Fill)
+            .height(Length::Shrink)
+            .style(style::Container::Frame);
+
+        let no_device_ctn = || {
+            container(text("No device detected").style(style::Text::Danger))
+                .padding(10)
+                .width(Length::Fill)
+                .style(style::Container::BorderedFrame)
+        };
+
+        let content = if !phone.adb_id.clone().is_empty() {
+            column![
+                text("Theme").size(25),
+                theme_ctn,
+                text("General").size(25),
+                general_ctn,
+                text("Current device").size(25),
+                warning_ctn,
+                device_specific_ctn,
+                backup_restore_ctn,
+            ]
+            .width(Length::Fill)
+            .spacing(20)
+        } else {
+            column![
+                text("Theme").size(25),
+                theme_ctn,
+                text("General").size(25),
+                general_ctn,
+                text("Current device").size(25),
+                no_device_ctn(),
+                text("Backup / Restore").size(25),
+                no_device_ctn(),
+            ]
+            .width(Length::Fill)
+            .spacing(20)
+        };
 
         container(content)
             .padding(10)

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -71,7 +71,7 @@ pub fn nav_menu<'a>(
         .style(style::Button::Primary);
 
     let device_list_text = match apps_view.loading_state {
-        ListLoadingState::FindingPhones => text("finding connected phone..."),
+        ListLoadingState::FindingPhones(_) => text("finding connected phone..."),
         _ => text("no devices/emulators found"),
     };
 


### PR DESCRIPTION
Quick and easy way to save the state of all the system apps on a device and restore it.

This feature is available in the UAD settings.

The backups are stored in the [`$cache_dir`](https://github.com/dirs-dev/dirs-rs#features) directory. Each device have its own directory identified by their ADB id (`adb devices`).

A backup has the following name formatting : `%Y-%m-%d_%H-%M_%S.json`.

**Note**: the `Export current selection` button and the non-intuitive auto import selection (see https://github.com/0x192/universal-android-debloater/issues/192) have been replaced by this new backup/restore system

Resolves #192 and #199