### PR TITLE
fix: UAD crash when interacting with work profiles

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -224,7 +224,7 @@ pub fn apply_pkg_state_commands(
         },
         _ => vec![],
     };
-    request_builder(commands, &package.name, &[*selected_user])
+    request_builder(commands, &package.name, &[*selected_user]).iter().map(|(_, command)| command.clone()).collect()
 }
 
 pub fn action_handler(
@@ -232,7 +232,7 @@ pub fn action_handler(
     package: &CorePackage,
     phone: &Phone,
     settings: &DeviceSettings,
-) -> Vec<String> {
+) -> Vec<(Option<usize>, String)> {
     // https://github.com/0x192/universal-android-debloater/wiki/ADB-reference
     // ALWAYS PUT THE COMMAND THAT CHANGES THE PACKAGE STATE FIRST!
     let commands = match package.state {
@@ -275,20 +275,20 @@ pub fn action_handler(
     }
 }
 
-pub fn request_builder(commands: Vec<&str>, package: &str, users: &[User]) -> Vec<String> {
+pub fn request_builder(commands: Vec<&str>, package: &str, users: &[User]) -> Vec<(Option<usize>, String)> {
     if !users.is_empty() {
         users
             .iter()
             .flat_map(|u| {
                 commands
                     .iter()
-                    .map(|c| format!("{} --user {} {}", c, u.id, package))
+                    .map(|c| (Some(u.index), format!("{} --user {} {}", c, u.id, package)))
             })
             .collect()
     } else {
         commands
             .iter()
-            .map(|c| format!("{} {}", c, package))
+            .map(|c| (None, format!("{} {}", c, package)))
             .collect()
     }
 }

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -224,7 +224,10 @@ pub fn apply_pkg_state_commands(
         },
         _ => vec![],
     };
-    request_builder(commands, &package.name, &[*selected_user]).iter().map(|(_, command)| command.clone()).collect()
+    request_builder(commands, &package.name, &[*selected_user])
+        .iter()
+        .map(|(_, command)| command.clone())
+        .collect()
 }
 
 pub fn action_handler(
@@ -275,7 +278,11 @@ pub fn action_handler(
     }
 }
 
-pub fn request_builder(commands: Vec<&str>, package: &str, users: &[User]) -> Vec<(Option<usize>, String)> {
+pub fn request_builder(
+    commands: Vec<&str>,
+    package: &str,
+    users: &[User],
+) -> Vec<(Option<usize>, String)> {
     if !users.is_empty() {
         users
             .iter()

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -321,7 +321,9 @@ impl List {
                         package.selected = false;
                     } else {
                         self.phone_packages[p.i_user.unwrap()][p.index].state = self.phone_packages
-                            [p.i_user.unwrap()][p.index].state.opposite(settings.device.disable_mode);
+                            [p.i_user.unwrap()][p.index]
+                            .state
+                            .opposite(settings.device.disable_mode);
                         self.phone_packages[p.i_user.unwrap()][p.index].selected = false;
                     }
                     self.selection

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -25,6 +25,7 @@ pub struct Selection {
 
 #[derive(Debug, Default, Clone)]
 pub struct PackageInfo {
+    pub i_user: Option<usize>,
     pub index: usize,
     pub removal: String,
 }
@@ -225,8 +226,9 @@ impl List {
                             &settings.device,
                         );
 
-                        for (i, action) in actions.into_iter().enumerate() {
+                        for (i, (i_user, action)) in actions.into_iter().enumerate() {
                             let p_info = PackageInfo {
+                                i_user,
                                 index: i_package,
                                 removal: package.removal.to_string(),
                             };
@@ -277,10 +279,12 @@ impl List {
                         &settings.device,
                     );
 
-                    for (j, action) in actions.into_iter().enumerate() {
+                    let package = &mut self.phone_packages[i_user][i];
+                    for (j, (i_user, action)) in actions.into_iter().enumerate() {
                         let p_info = PackageInfo {
+                            i_user,
                             index: i,
-                            removal: self.phone_packages[i_user][i].removal.to_string(),
+                            removal: package.removal.to_string(),
                         };
                         // Only the first command can change the package state
                         commands.push(Command::perform(
@@ -312,17 +316,13 @@ impl List {
                     let package = &mut self.phone_packages[i_user][p.index];
                     update_selection_count(&mut self.selection, package.state, false);
 
-                    if !settings.device.multi_user_mode {
+                    if !settings.device.multi_user_mode || p.i_user.is_none() {
                         package.state = package.state.opposite(settings.device.disable_mode);
                         package.selected = false;
                     } else {
-                        for u in &selected_device.user_list {
-                            self.phone_packages[u.index][p.index].state = self.phone_packages
-                                [u.index][p.index]
-                                .state
-                                .opposite(settings.device.disable_mode);
-                            self.phone_packages[u.index][p.index].selected = false;
-                        }
+                        self.phone_packages[p.i_user.unwrap()][p.index].state = self.phone_packages
+                            [p.i_user.unwrap()][p.index].state.opposite(settings.device.disable_mode);
+                        self.phone_packages[p.i_user.unwrap()][p.index].selected = false;
                     }
                     self.selection
                         .selected_packages

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -142,6 +142,7 @@ impl Settings {
                     *nb_running_async_adb_commands = 0;
                     for p in &r_packages {
                         let p_info = PackageInfo {
+                            i_user: None,
                             index: p.index,
                             removal: "RESTORE".to_string(),
                         };


### PR DESCRIPTION
I finally had the opportunity to get my hands on an Android 12 phone to try to reproduce the crash reported by multiple people!

Here is the conclusion:

On recent Android devices, you can't interact with the user of the work profile. Any adb commands involving this user will fail with a `Shell does not have permission to access user ${user}`.

**The crash**:  when the option `affect all the users of the phone` was on, UAD changed the state of the packages (in UAD memory) for all users as soon as the adb command for the user 0 succeed (yeah not great). Obviously, since no packages for the work profiles user were loaded in memory, UAD crashed by trying to changing non-existent data.

This pull request only fix the crash by preventing package state change in UAD before the associated command succeed (that sounds logic. I don't know why I didn't code this in the first place).

This means UAD will still try to mess up with the work profile user but without crashing or warning the user in the GUI it failed. 

**Next step**: inform the user in the GUI.

Closes #413, #386, #377