### PR TITLE
feat: warn the user when a work profile is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ and `Removed`.
 
 - [[#447](https://github.com/0x192/universal-android-debloater/pull/447)] **Backup/Restore the state of a device:** Quick and easy way to save the state of all the system apps on a device and restore it.
 
+- [[#450](https://github.com/0x192/universal-android-debloater/pull/450)] **Warn the user when a work profile is detected:** Displays a warning message when switching to a work profile user and displays unavailable work profile users in the settings.
+
 ### Changed
-- [[#374](https://github.com/0x192/universal-android-debloater/pull/374)] All settings are now persistent.
+- [[#374](https://github.com/0x192/universal-android-debloater/pull/374)] ALL settings are now persistent.
+
+### Fixed
+- [[#448](https://github.com/0x192/universal-android-debloater/pull/448)] UAD crash when interacting with work profiles on recent phones.
 
 ### Removed
 - The `Export current selection` button and the unintuitive auto import selection (see https://github.com/0x192/universal-android-debloater/issues/192) have been replaced by the new backup/restore system.
@@ -60,7 +65,7 @@ Huge thanks to [@KarlRamstedt](https://github.com/KarlRamstedt) for their help i
 - [[#121](https://github.com/0x192/universal-android-debloater/pull/121)] :arrows_counterclockwise: **UAD self-update**: UAD will now check at launch if there is a new version of itself and enable you to perform the update directly from the app! :rocket:
 
 ### Changed
-- [[#165](https://github.com/0x192/universal-android-debloater/issues/165)] UAD now tries every 500ms (for 1min) to initiate an ADB connection until a device is found during `FindingPhones`the loading state.
+- [[#165](https://github.com/0x192/universal-android-debloater/issues/165)] UAD now tries every 500ms (for 1min) to initiate an ADB connection until a device is found during the `FindingPhones` loading state.
 - All the init process was reworked and a status message is displayed at each stage (`DownloadingList`, `FindingPhones`,`LoadingPackages`,`UpdatingUad` `Ready`) so you know what is happening.
 - Minor UI changes
 

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -162,3 +162,21 @@ impl fmt::Display for DisplayablePath {
         write!(f, "{stem}")
     }
 }
+
+pub fn unavailable_users(user_list: &[User], packages: &[Vec<PackageRow>]) -> Vec<String> {
+    let mut unavailable_users = vec![];
+
+    for (u_index, p_list) in packages.iter().enumerate() {
+        if p_list.is_empty() {
+            unavailable_users.push(
+                user_list
+                    .iter()
+                    .find(|u| u.index == u_index)
+                    .unwrap()
+                    .id
+                    .to_string(),
+            );
+        }
+    }
+    unavailable_users
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -14,7 +14,10 @@ use views::settings::{Message as SettingsMessage, Settings as SettingsView};
 use widgets::navigation_menu::nav_menu;
 
 use iced::widget::column;
-use iced::{window::Settings as Window, Application, Command, Element, Length, Renderer, Settings};
+use iced::{
+    window::Settings as Window, Alignment, Application, Command, Element, Length, Renderer,
+    Settings,
+};
 use std::{env, path::PathBuf};
 
 #[cfg(feature = "self-update")]
@@ -309,6 +312,7 @@ impl Application for UadGui {
 
         column![navigation_container, main_container]
             .width(Length::Fill)
+            .align_items(Alignment::Center)
             .into()
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -306,7 +306,7 @@ impl Application for UadGui {
                 .map(Message::AboutAction),
             View::Settings => self
                 .settings_view
-                .view(&selected_device)
+                .view(&self.apps_view.phone_packages, &selected_device)
                 .map(Message::SettingsAction),
         };
 

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -13,7 +13,7 @@ use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
 use iced::widget::{
     button, column, container, pick_list, row, scrollable, text, text_input, Space,
 };
-use iced::{Alignment, Command, Element, Length, Renderer};
+use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 
 #[derive(Debug, Default, Clone)]
 pub struct Selection {
@@ -483,16 +483,41 @@ impl List {
                 .spacing(10)
                 .align_items(Alignment::Center);
 
-                let content = column![
-                    control_panel,
-                    packages_scrollable,
-                    description_panel,
-                    action_row,
-                ]
-                .width(Length::Fill)
-                .spacing(10)
-                .align_items(Alignment::Center);
+                let unavailable = container(
+                    column![
+                        text("ADB is not authorized to access this user!").size(22)
+                            .style(style::Text::Danger),
+                        text("The most likely reason is that it is the user of your work profile (also called Secure Folder on Samsung devices). There's really no solution, other than disabling your work profile completely in your device settings.")
+                            .style(style::Text::Commentary)
+                            .horizontal_alignment(alignment::Horizontal::Center),
+                    ]
+                    .spacing(6)
+                    .align_items(Alignment::Center)
+                )
+                .padding(10)
+                .center_x()
+                .style(style::Container::BorderedFrame);
 
+                let content = if !self.phone_packages[self.selected_user.unwrap().index].is_empty()
+                {
+                    column![
+                        control_panel,
+                        packages_scrollable,
+                        description_panel,
+                        action_row,
+                    ]
+                    .width(Length::Fill)
+                    .spacing(10)
+                    .align_items(Alignment::Center)
+                } else {
+                    column![
+                        control_panel,
+                        container(unavailable).height(Length::Fill).center_y(),
+                    ]
+                    .width(Length::Fill)
+                    .spacing(10)
+                    .align_items(Alignment::Center)
+                };
                 container(content).height(Length::Fill).padding(10).into()
             }
         }

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -487,7 +487,7 @@ impl List {
                     column![
                         text("ADB is not authorized to access this user!").size(22)
                             .style(style::Text::Danger),
-                        text("The most likely reason is that it is the user of your work profile (also called Secure Folder on Samsung devices). There's really no solution, other than disabling your work profile completely in your device settings.")
+                        text("The most likely reason is that it is the user of your work profile (also called Secure Folder on Samsung devices). There's really no solution, other than completely disabling your work profile in your device settings.")
                             .style(style::Text::Commentary)
                             .horizontal_alignment(alignment::Horizontal::Center),
                     ]

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -4,7 +4,7 @@ use crate::core::save::{
 };
 use crate::core::sync::{perform_adb_commands, CommandType, Phone};
 use crate::core::theme::Theme;
-use crate::core::utils::{open_url, string_to_theme, DisplayablePath};
+use crate::core::utils::{open_url, string_to_theme, unavailable_users, DisplayablePath};
 use crate::gui::style;
 use crate::gui::views::list::PackageInfo;
 use crate::gui::widgets::package_row::PackageRow;
@@ -178,7 +178,11 @@ impl Settings {
         }
     }
 
-    pub fn view(&self, phone: &Phone) -> Element<Message, Renderer<Theme>> {
+    pub fn view(
+        &self,
+        packages: &[Vec<PackageRow>],
+        phone: &Phone,
+    ) -> Element<Message, Renderer<Theme>> {
         let radio_btn_theme = Theme::ALL
             .iter()
             .fold(row![].spacing(10), |column, option| {
@@ -230,10 +234,14 @@ impl Settings {
         .width(Length::Fill)
         .style(style::Container::BorderedFrame);
 
-        let multi_user_mode_descr =
-            text("Disabling this setting will typically prevent affecting your work profile")
-                .style(style::Text::Commentary)
-                .size(15);
+        let multi_user_mode_descr = row![
+            text("This will not affect the following protected work profile users: ")
+                .size(15)
+                .style(style::Text::Commentary),
+            text(unavailable_users(&phone.user_list, packages).join(", "))
+                .size(15)
+                .style(style::Text::Danger)
+        ];
 
         let multi_user_mode_checkbox = checkbox(
             "Affect all the users of the phone (not only the selected user)",


### PR DESCRIPTION
- [x] Display a warning message when switching to a work profile user

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/55300518/202927646-ad951b47-f7a7-441d-a4da-b72217824cd7.png)

</details>

- [x] Display the work profile user in the settings (next to the `Affect all the users...` setting) with a warning message