### PR TITLE
refacotr: improve error handling

### DIFF
--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -113,7 +113,15 @@ pub fn restore_backup(
     packages: &[Vec<PackageRow>],
     settings: &DeviceSettings,
 ) -> Result<Vec<BackupPackage>, String> {
-    match fs::read_to_string(settings.backup.selected.as_ref().unwrap().path.clone()) {
+    match fs::read_to_string(
+        settings
+            .backup
+            .selected
+            .as_ref()
+            .ok_or("field should be Some type")?
+            .path
+            .clone(),
+    ) {
         Ok(data) => {
             let phone_backup: PhoneBackup =
                 serde_json::from_str(&data).expect("Unable to parse backup file");
@@ -143,7 +151,10 @@ pub fn restore_backup(
                     let p_commands = apply_pkg_state_commands(
                         &package,
                         &backup_package.state,
-                        &settings.backup.selected_user.unwrap(),
+                        &settings
+                            .backup
+                            .selected_user
+                            .ok_or("field should be Some type")?,
                         selected_device,
                     );
                     if !p_commands.is_empty() {

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -78,14 +78,23 @@ pub fn adb_shell_command(shell: bool, args: &str) -> Result<String, String> {
         }
         Ok(o) => {
             if !o.status.success() {
-                let stdout = String::from_utf8(o.stdout).unwrap().trim_end().to_string();
-                let stderr = String::from_utf8(o.stderr).unwrap().trim_end().to_string();
+                let stdout = String::from_utf8(o.stdout)
+                    .map_err(|e| e.to_string())?
+                    .trim_end()
+                    .to_string();
+                let stderr = String::from_utf8(o.stderr)
+                    .map_err(|e| e.to_string())?
+                    .trim_end()
+                    .to_string();
 
                 // ADB does really weird things. Some errors are not redirected to stderr
                 let err = if stdout.is_empty() { stderr } else { stdout };
                 Err(err)
             } else {
-                Ok(String::from_utf8(o.stdout).unwrap().trim_end().to_string())
+                Ok(String::from_utf8(o.stdout)
+                    .map_err(|e| e.to_string())?
+                    .trim_end()
+                    .to_string())
             }
         }
     }

--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -210,7 +210,7 @@ pub fn load_debloat_lists(remote: bool) -> (Result<PackageHashMap, PackageHashMa
             .call()
             {
                 Ok(data) => {
-                    let text = data.into_string().unwrap();
+                    let text = data.into_string().expect("response should be Ok type");
                     fs::write(cached_uad_lists.clone(), &text).expect("Unable to write file");
                     let list = serde_json::from_str(&text).expect("Unable to parse");
                     OperationResult::Ok(list)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -314,8 +314,8 @@ impl Application for UadGui {
 }
 
 impl UadGui {
-    pub fn start() {
-        let settings: Settings<()> = Settings {
+    pub fn start() -> iced::Result {
+        Self::run(Settings {
             window: Window {
                 size: (1050, 800),
                 resizable: true,
@@ -323,8 +323,7 @@ impl UadGui {
                 ..iced::window::Settings::default()
             },
             default_text_size: 17,
-            ..iced::Settings::default()
-        };
-        _ = Self::run(settings);
+            ..Settings::default()
+        })
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -325,6 +325,6 @@ impl UadGui {
             default_text_size: 17,
             ..iced::Settings::default()
         };
-        Self::run(settings).unwrap_err();
+        _ = Self::run(settings);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,9 @@ static CONFIG_DIR: PathBuf = setup_uad_dir(dirs::config_dir());
 #[dynamic]
 static CACHE_DIR: PathBuf = setup_uad_dir(dirs::cache_dir());
 
-fn main() {
+fn main() -> iced::Result {
     setup_logger().expect("setup logging");
-    gui::UadGui::start();
+    gui::UadGui::start()
 }
 
 pub fn setup_logger() -> Result<(), fern::InitError> {


### PR DESCRIPTION
- Remove unwrap calls
- Don't change func signatures for func which don't already return Result/Option

Would appreciate feedback as I'm a beginner to Rust :+1: 