### PR TITLE
Fixed mold path for M1 Macs after installing with homebrew

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,3 @@ rustflags = ["-C", "target-feature=+crt-static"]
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-
-[target.aarch64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=/opt/homebrew/bin/ld64.mold"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -7,4 +7,4 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
 
 [target.aarch64-apple-darwin]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
+rustflags = ["-C", "link-arg=--ld-path=/opt/homebrew/bin/ld64.mold"]


### PR DESCRIPTION
This fixed build errors I was seeing on an M1 Mac. After installing mold with homebrew and changing the path in the config file, everything built and worked.