### PR TITLE
refactor: replaces `drain_filter` (unstable) with `retain` (stable)

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -154,12 +154,7 @@ impl List {
                                 false,
                             );
 
-                            self.selection.selected_packages = self
-                                .selection
-                                .selected_packages
-                                .iter()
-                                .partition::<Vec<_>, _>(|&&s_i| s_i == i)
-                                .1;
+                            self.selection.selected_packages.retain(|&s_i| s_i != i);
                         }
                     } else if !self.selection.selected_packages.contains(&i) {
                         self.selection.selected_packages.push(i);
@@ -209,12 +204,7 @@ impl List {
                             if package.selected {
                                 self.selection.selected_packages.push(i_package);
                             } else {
-                                self.selection.selected_packages = self
-                                    .selection
-                                    .selected_packages
-                                    .iter()
-                                    .partition(|&&s_i| s_i == i_package)
-                                    .1;
+                                self.selection.selected_packages.retain(|&s_i| s_i != i_package);
                             }
                             update_selection_count(
                                 &mut self.selection,
@@ -267,20 +257,16 @@ impl List {
 
                 match action {
                     Action::Remove => {
-                        selected_packages = selected_packages
-                            .into_iter()
-                            .partition(|&i| {
-                                self.phone_packages[i_user][i].state != PackageState::Enabled
-                            })
-                            .1;
+                        selected_packages.retain(|&i| {
+                            self.phone_packages[i_user][i].state == PackageState::Enabled
+                        })
+;
                     }
                     Action::Restore => {
-                        selected_packages = selected_packages
-                            .into_iter()
-                            .partition(|&i| {
-                                self.phone_packages[i_user][i].state == PackageState::Enabled
+                        selected_packages
+                            .retain(|&i| {
+                                self.phone_packages[i_user][i].state != PackageState::Enabled
                             })
-                            .1;
                     }
                 }
                 let mut commands = vec![];
@@ -339,12 +325,7 @@ impl List {
                             .opposite(settings.device.disable_mode);
                         self.phone_packages[p.i_user.unwrap()][p.index].selected = false;
                     }
-                    self.selection.selected_packages = self
-                        .selection
-                        .selected_packages
-                        .iter()
-                        .partition(|&&s_i| s_i == p.index)
-                        .1;
+                    self.selection.selected_packages.retain(|&s_i| s_i != p.index);
                     Self::filter_package_lists(self);
                 }
                 Command::none()

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -204,7 +204,9 @@ impl List {
                             if package.selected {
                                 self.selection.selected_packages.push(i_package);
                             } else {
-                                self.selection.selected_packages.retain(|&s_i| s_i != i_package);
+                                self.selection
+                                    .selected_packages
+                                    .retain(|&s_i| s_i != i_package);
                             }
                             update_selection_count(
                                 &mut self.selection,
@@ -259,15 +261,10 @@ impl List {
                     Action::Remove => {
                         selected_packages.retain(|&i| {
                             self.phone_packages[i_user][i].state == PackageState::Enabled
-                        })
-;
+                        });
                     }
-                    Action::Restore => {
-                        selected_packages
-                            .retain(|&i| {
-                                self.phone_packages[i_user][i].state != PackageState::Enabled
-                            })
-                    }
+                    Action::Restore => selected_packages
+                        .retain(|&i| self.phone_packages[i_user][i].state != PackageState::Enabled),
                 }
                 let mut commands = vec![];
                 for i in selected_packages {
@@ -325,7 +322,9 @@ impl List {
                             .opposite(settings.device.disable_mode);
                         self.phone_packages[p.i_user.unwrap()][p.index].selected = false;
                     }
-                    self.selection.selected_packages.retain(|&s_i| s_i != p.index);
+                    self.selection
+                        .selected_packages
+                        .retain(|&s_i| s_i != p.index);
                     Self::filter_package_lists(self);
                 }
                 Command::none()

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -153,9 +153,13 @@ impl List {
                                 self.phone_packages[i_user][i].state,
                                 false,
                             );
-                            self.selection
+
+                            self.selection.selected_packages = self
+                                .selection
                                 .selected_packages
-                                .drain_filter(|s_i| *s_i == i);
+                                .iter()
+                                .partition::<Vec<_>, _>(|&&s_i| s_i == i)
+                                .1;
                         }
                     } else if !self.selection.selected_packages.contains(&i) {
                         self.selection.selected_packages.push(i);
@@ -205,9 +209,12 @@ impl List {
                             if package.selected {
                                 self.selection.selected_packages.push(i_package);
                             } else {
-                                self.selection
+                                self.selection.selected_packages = self
+                                    .selection
                                     .selected_packages
-                                    .drain_filter(|s_i| *s_i == i_package);
+                                    .iter()
+                                    .partition(|&&s_i| s_i == i_package)
+                                    .1;
                             }
                             update_selection_count(
                                 &mut self.selection,
@@ -260,14 +267,20 @@ impl List {
 
                 match action {
                     Action::Remove => {
-                        selected_packages.drain_filter(|i| {
-                            self.phone_packages[i_user][*i].state != PackageState::Enabled
-                        });
+                        selected_packages = selected_packages
+                            .into_iter()
+                            .partition(|&i| {
+                                self.phone_packages[i_user][i].state != PackageState::Enabled
+                            })
+                            .1;
                     }
                     Action::Restore => {
-                        selected_packages.drain_filter(|i| {
-                            self.phone_packages[i_user][*i].state == PackageState::Enabled
-                        });
+                        selected_packages = selected_packages
+                            .into_iter()
+                            .partition(|&i| {
+                                self.phone_packages[i_user][i].state == PackageState::Enabled
+                            })
+                            .1;
                     }
                 }
                 let mut commands = vec![];
@@ -326,9 +339,12 @@ impl List {
                             .opposite(settings.device.disable_mode);
                         self.phone_packages[p.i_user.unwrap()][p.index].selected = false;
                     }
-                    self.selection
+                    self.selection.selected_packages = self
+                        .selection
                         .selected_packages
-                        .drain_filter(|s_i| *s_i == p.index);
+                        .iter()
+                        .partition(|&&s_i| s_i == p.index)
+                        .1;
                     Self::filter_package_lists(self);
                 }
                 Command::none()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![windows_subsystem = "windows"]
-#![feature(drain_filter)]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
Addresses #252 

- Removes use of `drain_filter` unstable feature

### Cons
- Memory is not reused.