### PR TITLE
pkg: add 51 packages and an extra list "WearOS"

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20945,7 +20945,7 @@
   {
     "id": "com.google.android.wearable.assistant",
     "list": "WearOS",
-    "description": "Google Assistant for Android wearables.",
+    "description": "Google Assistant for Android wearables (https://play.google.com/store/apps/details?id=com.google.android.wearable.assistant)\n\nHas obviously all the dangerous permissions: https://beta.pithus.org/report/efccf27aa68d9c263e4288d38af76f855b5fd4156034ebdaabeb185d8c4f1411",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -20958,7 +20958,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.samsung.advancedcallservice",
@@ -20972,7 +20972,7 @@
   {
     "id": "com.google.android.clockwork.oemsetup",
     "list": "WearOS",
-    "description": "Installs carrier apps after the first time setup. Haven't noticed any concequences after uninstalling. I also saw some similar bloatware packages on the net, ending with clockwork.gestures.tutorial - first time use tutorial or clockwork.flashlight, clockwork.nfc, clockwork.brightness",
+    "description": "Installs carrier apps after the first time setup. Haven't noticed any consequences after uninstalling. I also saw some similar bloatware packages on the net, ending with clockwork.gestures.tutorial - first time use tutorial or clockwork.flashlight, clockwork.nfc, clockwork.brightness",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -20994,7 +20994,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.shealthmonitor",
@@ -21003,7 +21003,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.watch.cameracontroller",
@@ -21035,7 +21035,7 @@
   {
     "id": "com.samsung.android.watch.runestone.app",
     "list": "WearOS",
-    "description": "Customization Service from Samsung. IMHO doesn't do anything useful.",
+    "description": "Customization Service from Samsung. Provides customized content and recommendations. Collects a lot of personal information.\nSee: https://www.samsung.com/us/account/customization-service/\n\nPithus analysis: https://beta.pithus.org/report/0f26752e636a9689bf0603e6023939e23a8cbd7197dea7b44c7ac93e2a930c24",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21354,12 +21354,12 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.samsung.android.wear.musictransfer",
     "list": "WearOS",
-    "description": "Used to sync music with watch.",
+    "description": "Used to sync music with the watch.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21368,7 +21368,7 @@
   {
     "id": "com.samsung.android.wearable.setupwizard",
     "list": "WearOS",
-    "description": "Safe to remove after first time setup.",
+    "description": "Samsung Wearable Setup Wizard\nThe first time you turn your device on, a Welcome screen is displayed. It guides you through the basics of setting up your device.\nIt's the setup for Samsung services.\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21377,7 +21377,7 @@
   {
     "id": "com.samsung.android.wear.contacts.sync",
     "list": "WearOS",
-    "description": "Handles 'open on phone' events. Also, settings often crash when this uninstalled.",
+    "description": "Handles 'open on phone' events. Also, settings often crash when this is uninstalled.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21386,7 +21386,7 @@
   {
     "id": "com.android.cts.ctsshim",
     "list": "WearOS",
-    "description": "Basically an app for devs to compatibility test their app.",
+    "description": "Compatibility Test Service. Used by developers to identify and resolve compatibility issues with Android apps.\nA shim is basically a compatibility layer for an API, that makes sure anything that uses the API does so correctly.\nhttps://android.googlesource.com/platform/frameworks/base/+/51e458e/packages/CtsShim\nhttps://en.wikipedia.org/wiki/Shim_(computing)",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21422,11 +21422,11 @@
   {
     "id": "com.samsung.android.stextclassifier",
     "list": "Oem",
-    "description": "From https://developer.android.com/reference/android/view/textclassifier/TextClassifier:\nInterface for providing text classification related features.\n\nThe TextClassifier may be used to understand the meaning of text, as well as generating predicted next actions based on the text.\n\nSo it got something to do with text/spelling correction? But a samsung implementation of it. It needs some further testing, so far it doesn't affect even the autocorrect.",
+    "description": "From https://developer.android.com/reference/android/view/textclassifier/TextClassifier:\nInterface for providing text classification related features.\n\nThe TextClassifier may be used to understand the meaning of text, as well as generating predicted next actions based on the text.\n\nSo it got something to do with text/spelling correction? But a samsung implementation of it. It needs some further testing, so far it doesn't affect even the auto-correct.\nNote: this app has no permission and doesn't run in background when not in used",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.sec.android.soagent",
@@ -21435,12 +21435,12 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.samsung.packageinstalleroverlay",
     "list": "Oem",
-    "description": "",
+    "description": "Most likely the overlay that appears when you installed an application.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21449,7 +21449,7 @@
   {
     "id": "com.google.android.wearable.healthservices",
     "list": "WearOS",
-    "description": "Health Services by Google\nPlay Store link: https://play.google.com/store/apps/details?id=com.google.android.wearable.healthservices&hl=en_US&gl=US\n\nDisabling this on my Watch5 broke heart rate measuring and some workouts.",
+    "description": "Health Services by Google\n (https://play.google.com/store/apps/details?id=com.google.android.wearable.healthservices)\n\nDisabling this on a Watch5 broke heart rate measuring and some workouts.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21458,11 +21458,11 @@
   {
     "id": "com.samsung.android.service.health",
     "list": "WearOS",
-    "description": "Health Platform\n\nIt is a data aggregator. You can use it to link multiple health apps (like Strava, google fit etc) together. This app will unify their collected data and store them all together.",
+    "description": "Health Platform (https://play.google.com/store/apps/details?id=com.samsung.android.service.health)\n\nIt is a data aggregator. You can use it to link multiple health apps (like Strava, google fit etc) together. This app will unify their collected data and store them all together.\nConstantly phones to Samsung servers.\n\nPithus analysis: https://beta.pithus.org/report/968364daf4fbb1828dfe9d8dbcce6d5f7f9a79522a5267c4be5bba19e6cd88b0",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Expert"
+    "removal": "Advanced"
   },
   {
     "id": "com.samsung.android.wear.shealth",
@@ -21483,27 +21483,18 @@
     "removal": "Expert"
   },
   {
-    "id": "com.samsung.android.watch.timer",
-    "list": "WearOS",
-    "description": "Timer",
-    "dependencies": [],
-    "neededBy": [],
-    "labels": [],
-    "removal": "Recomended"
-  },
-  {
     "id": "com.samsung.android.watch.stopwatch",
     "list": "WearOS",
-    "description": "Stopwatch",
+    "description": "Samsung Stopwatch",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recomended"
+    "removal": "Recommended"
   },
   {
     "id": "com.samsung.android.watch.screencapture",
     "list": "WearOS",
-    "description": "This is responsible for taking screenshots.",
+    "description": "Provides the ability to take screenshots from the smart watch.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21512,7 +21503,7 @@
   {
     "id": "com.samsung.android.watch.flashlight",
     "list": "WearOS",
-    "description": "Flashlight",
+    "description": "Samsung Flashlight",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21525,25 +21516,25 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recomended"
+    "removal": "Recommended"
   },
   {
     "id": "com.samsung.android.watch.alarm",
     "list": "WearOS",
-    "description": "Alarms.",
+    "description": "Samsung Alarm app.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recomended"
+    "removal": "Recommended"
   },
   {
     "id": "com.samsung.android.storage.watchstoragemanager",
     "list": "WearOS",
-    "description": "Storage manager. Based on internet posts it's not safe to disable.",
+    "description": "Storage manager. DO NOT REMOVE THIS",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Expert"
+    "removal": "Unsafe"
   },
   {
     "id": "com.samsung.android.watch.timer",
@@ -21552,12 +21543,12 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recomended"
+    "removal": "Recommended"
   },
   {
     "id": "com.samsung.android.gallery.watch",
     "list": "WearOS",
-    "description": "Gallery app",
+    "description": "Samsung Watch gallery app",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21575,7 +21566,7 @@
   {
     "id": "com.google.android.apps.wearable.settings",
     "list": "WearOS",
-    "description": "Settings",
+    "description": "WearOS settings",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -21583,7 +21574,7 @@
   },
   {
     "id": "com.android.modulemetadata",
-    "list": "aosp",
+    "list": "Aosp",
     "description": "It's used to manage and store metadata about installed modules, and is accessed by the system server. Breaks some core functionality if disabled.",
     "dependencies": [],
     "neededBy": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -21332,11 +21332,11 @@
   {
     "id": "com.samsung.android.wear.contacts.sync",
     "list": "WearOS",
-    "description": "Syncs contacts from phone to watch. I uninstalled it since i don't use my watch to call anyone.",
+    "description": "Handles 'open on phone' events. Also, settings often crash when this uninstalled.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   {
     "id": "com.android.cts.ctsshim",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -21448,7 +21448,7 @@
   },
   {
     "id": "com.google.android.wearable.healthservices",
-    "list": "Oem",
+    "list": "WearOS",
     "description": "Health Services by Google\nPlay Store link: https://play.google.com/store/apps/details?id=com.google.android.wearable.healthservices&hl=en_US&gl=US\n\nDisabling this on my Watch5 broke heart rate measuring and some workouts.",
     "dependencies": [],
     "neededBy": [],
@@ -21457,8 +21457,134 @@
   },
   {
     "id": "com.samsung.android.service.health",
-    "list": "Oem",
+    "list": "WearOS",
     "description": "Health Platform\n\nIt is a data aggregator. You can use it to link multiple health apps (like Strava, google fit etc) together. This app will unify their collected data and store them all together.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.wear.shealth",
+    "list": "WearOS",
+    "description": "Samsung Health app for WearOS.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.wearable.samsungaccount",
+    "list": "WearOS",
+    "description": "Samsung account settings. Breaks settings app if uninstalled.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.watch.timer",
+    "list": "WearOS",
+    "description": "Timer",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recomended"
+  },
+  {
+    "id": "com.samsung.android.watch.stopwatch",
+    "list": "WearOS",
+    "description": "Stopwatch",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recomended"
+  },
+  {
+    "id": "com.samsung.android.watch.screencapture",
+    "list": "WearOS",
+    "description": "This is responsible for taking screenshots.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.flashlight",
+    "list": "WearOS",
+    "description": "Flashlight",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.compass",
+    "list": "WearOS",
+    "description": "Samsung Compass app.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recomended"
+  },
+  {
+    "id": "com.samsung.android.watch.alarm",
+    "list": "WearOS",
+    "description": "Alarms.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recomended"
+  },
+  {
+    "id": "com.samsung.android.storage.watchstoragemanager",
+    "list": "WearOS",
+    "description": "Storage manager. Based on internet posts it's not safe to disable.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.watch.timer",
+    "list": "WearOS",
+    "description": "Timer app from Samsung.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recomended"
+  },
+  {
+    "id": "com.samsung.android.gallery.watch",
+    "list": "WearOS",
+    "description": "Gallery app",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.google.android.wearable.ambient",
+    "list": "WearOS",
+    "description": "It's like doze on Android phones. Not recommended to disable, as this package reduces battery drain when idle.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.google.android.apps.wearable.settings",
+    "list": "WearOS",
+    "description": "Settings",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.android.modulemetadata",
+    "list": "aosp",
+    "description": "It's used to manage and store metadata about installed modules, and is accessed by the system server. Breaks some core functionality if disabled.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20944,7 +20944,7 @@
   },
   {
     "id": "com.google.android.wearable.assistant",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Google Assistant for Android wearables (https://play.google.com/store/apps/details?id=com.google.android.wearable.assistant)\n\nHas obviously all the dangerous permissions: https://beta.pithus.org/report/efccf27aa68d9c263e4288d38af76f855b5fd4156034ebdaabeb185d8c4f1411",
     "dependencies": [],
     "neededBy": [],
@@ -20953,7 +20953,7 @@
   },
   {
     "id": "com.google.android.wearable.batteryservices",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "It's used to manage battery-related things on Android smartwatches, like monitoring the battery level, managing power consumption (auto battery saving I think), and handling battery-related events (pop-up when battery at 15%, etc.). It is typically used by developers to create battery-aware applications for wearable devices.",
     "dependencies": [],
     "neededBy": [],
@@ -20971,7 +20971,7 @@
   },
   {
     "id": "com.google.android.clockwork.oemsetup",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Installs carrier apps after the first time setup. Haven't noticed any consequences after uninstalling. I also saw some similar bloatware packages on the net, ending with clockwork.gestures.tutorial - first time use tutorial or clockwork.flashlight, clockwork.nfc, clockwork.brightness",
     "dependencies": [],
     "neededBy": [],
@@ -20980,7 +20980,7 @@
   },
   {
     "id": "com.google.android.apps.wearable.retailattractloop",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Demo mode - you see it in the stores (the video playing while idle).",
     "dependencies": [],
     "neededBy": [],
@@ -20989,7 +20989,7 @@
   },
   {
     "id": "com.samsung.android.mediacontroller",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Ability to controls phone's audio from your watch.",
     "dependencies": [],
     "neededBy": [],
@@ -21007,7 +21007,7 @@
   },
   {
     "id": "com.samsung.android.watch.cameracontroller",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Mirrors phone's camera to your watch. I can't find a use case for my usage. Safe to remove.",
     "dependencies": [],
     "neededBy": [],
@@ -21016,7 +21016,7 @@
   },
   {
     "id": "com.samsung.android.watch.findmywatch",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "The watch will start ringing, if connected to phone via BT or WiFi, when pressing 'start ringing' on the phone. Also fetches location and is able to lock or factory reset.",
     "dependencies": [],
     "neededBy": [],
@@ -21025,7 +21025,7 @@
   },
   {
     "id": "com.samsung.android.watch.findmyphone",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "The phone will start ringing, if connected to watch via BT or WiFi, when pressing 'start ringing' on the watch.",
     "dependencies": [],
     "neededBy": [],
@@ -21034,7 +21034,7 @@
   },
   {
     "id": "com.samsung.android.watch.runestone.app",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Customization Service from Samsung. Provides customized content and recommendations. Collects a lot of personal information.\nSee: https://www.samsung.com/us/account/customization-service/\n\nPithus analysis: https://beta.pithus.org/report/0f26752e636a9689bf0603e6023939e23a8cbd7197dea7b44c7ac93e2a930c24",
     "dependencies": [],
     "neededBy": [],
@@ -21043,7 +21043,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.analoguefont",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21052,7 +21052,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.animal",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21061,7 +21061,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.aremoji",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21070,7 +21070,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.basicclock",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21079,7 +21079,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.basicdashboard",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21088,7 +21088,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.bespoke",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21097,7 +21097,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.bitmoji",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21106,7 +21106,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.boldindex",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21115,7 +21115,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.digitalfont",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21124,7 +21124,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.digitalmodular",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21133,7 +21133,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.dualwatch",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21142,7 +21142,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.dynamicfont",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21151,7 +21151,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.gradientfont",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21160,7 +21160,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.healthmodular",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21169,7 +21169,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.infomodular",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21178,7 +21178,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.large",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21187,7 +21187,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.livewallpaper",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21196,7 +21196,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.mypebble",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21205,7 +21205,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.myphoto",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21214,7 +21214,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.mystyle",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21223,7 +21223,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.premiumanalog",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21232,7 +21232,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.simpleanalogue",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21241,7 +21241,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.simplecomplication",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21250,7 +21250,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.superfiction",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21259,7 +21259,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.together",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21268,7 +21268,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.typography",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21277,7 +21277,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.weather",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21286,7 +21286,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.analogmodular",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21295,7 +21295,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.simpleclassic",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Preinstalled watchface.",
     "dependencies": [],
     "neededBy": [],
@@ -21304,7 +21304,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.emergency",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Watchface in the emergency launcher.",
     "dependencies": [],
     "neededBy": [],
@@ -21313,7 +21313,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.companionhelper",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Watchfaces fail to load without this. Removing it also breaks editing and changing watchfaces.",
     "dependencies": [],
     "neededBy": [],
@@ -21322,7 +21322,7 @@
   },
   {
     "id": "com.samsung.android.watch.watchface.tickingsound",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Ticking sound on watchfaces that support it.",
     "dependencies": [],
     "neededBy": [],
@@ -21331,7 +21331,7 @@
   },
   {
     "id": "com.samsung.android.watch.weather",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Weather application from Samsung.",
     "dependencies": [],
     "neededBy": [],
@@ -21340,7 +21340,7 @@
   },
   {
     "id": "com.samsung.android.watch.worldclock",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Worldclock app. This also includes a widget, displaying time in different time zones.",
     "dependencies": [],
     "neededBy": [],
@@ -21349,7 +21349,7 @@
   },
   {
     "id": "com.samsung.android.wear.blockednumber",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Blocked number storage. Doesn't affect the dialer or contacts.",
     "dependencies": [],
     "neededBy": [],
@@ -21358,7 +21358,7 @@
   },
   {
     "id": "com.samsung.android.wear.musictransfer",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Used to sync music with the watch.",
     "dependencies": [],
     "neededBy": [],
@@ -21367,7 +21367,7 @@
   },
   {
     "id": "com.samsung.android.wearable.setupwizard",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Wearable Setup Wizard\nThe first time you turn your device on, a Welcome screen is displayed. It guides you through the basics of setting up your device.\nIt's the setup for Samsung services.\n",
     "dependencies": [],
     "neededBy": [],
@@ -21376,7 +21376,7 @@
   },
   {
     "id": "com.samsung.android.wear.contacts.sync",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Handles 'open on phone' events. Also, settings often crash when this is uninstalled.",
     "dependencies": [],
     "neededBy": [],
@@ -21385,7 +21385,7 @@
   },
   {
     "id": "com.android.cts.ctsshim",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Compatibility Test Service. Used by developers to identify and resolve compatibility issues with Android apps.\nA shim is basically a compatibility layer for an API, that makes sure anything that uses the API does so correctly.\nhttps://android.googlesource.com/platform/frameworks/base/+/51e458e/packages/CtsShim\nhttps://en.wikipedia.org/wiki/Shim_(computing)",
     "dependencies": [],
     "neededBy": [],
@@ -21412,7 +21412,7 @@
   },
   {
     "id": "com.samsung.android.wcs.exstention",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Internet Extensions\nSamsung Internet for Android allows users to customize their browsing experience by installing extensions, which are additional software packages that add new features and functionality to the browser and help developers offer tailored services to users on mobile devices.\n\nNOTE: Disabling this broke the UI on my Watch5 for some reason so PROCEED WITH CAUTION.",
     "dependencies": [],
     "neededBy": [],
@@ -21448,7 +21448,7 @@
   },
   {
     "id": "com.google.android.wearable.healthservices",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Health Services by Google\n (https://play.google.com/store/apps/details?id=com.google.android.wearable.healthservices)\n\nDisabling this on a Watch5 broke heart rate measuring and some workouts.",
     "dependencies": [],
     "neededBy": [],
@@ -21457,7 +21457,7 @@
   },
   {
     "id": "com.samsung.android.service.health",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Health Platform (https://play.google.com/store/apps/details?id=com.samsung.android.service.health)\n\nIt is a data aggregator. You can use it to link multiple health apps (like Strava, google fit etc) together. This app will unify their collected data and store them all together.\nConstantly phones to Samsung servers.\n\nPithus analysis: https://beta.pithus.org/report/968364daf4fbb1828dfe9d8dbcce6d5f7f9a79522a5267c4be5bba19e6cd88b0",
     "dependencies": [],
     "neededBy": [],
@@ -21466,7 +21466,7 @@
   },
   {
     "id": "com.samsung.android.wear.shealth",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Health app for WearOS.",
     "dependencies": [],
     "neededBy": [],
@@ -21475,7 +21475,7 @@
   },
   {
     "id": "com.samsung.android.wearable.samsungaccount",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung account settings. Breaks settings app if uninstalled.",
     "dependencies": [],
     "neededBy": [],
@@ -21484,7 +21484,7 @@
   },
   {
     "id": "com.samsung.android.watch.stopwatch",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Stopwatch",
     "dependencies": [],
     "neededBy": [],
@@ -21493,7 +21493,7 @@
   },
   {
     "id": "com.samsung.android.watch.screencapture",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Provides the ability to take screenshots from the smart watch.",
     "dependencies": [],
     "neededBy": [],
@@ -21502,7 +21502,7 @@
   },
   {
     "id": "com.samsung.android.watch.flashlight",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Flashlight",
     "dependencies": [],
     "neededBy": [],
@@ -21511,7 +21511,7 @@
   },
   {
     "id": "com.samsung.android.watch.compass",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Compass app.",
     "dependencies": [],
     "neededBy": [],
@@ -21520,7 +21520,7 @@
   },
   {
     "id": "com.samsung.android.watch.alarm",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Alarm app.",
     "dependencies": [],
     "neededBy": [],
@@ -21529,7 +21529,7 @@
   },
   {
     "id": "com.samsung.android.storage.watchstoragemanager",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Storage manager. DO NOT REMOVE THIS",
     "dependencies": [],
     "neededBy": [],
@@ -21538,7 +21538,7 @@
   },
   {
     "id": "com.samsung.android.watch.timer",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Timer app from Samsung.",
     "dependencies": [],
     "neededBy": [],
@@ -21547,7 +21547,7 @@
   },
   {
     "id": "com.samsung.android.gallery.watch",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "Samsung Watch gallery app",
     "dependencies": [],
     "neededBy": [],
@@ -21556,7 +21556,7 @@
   },
   {
     "id": "com.google.android.wearable.ambient",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "It's like doze on Android phones. Not recommended to disable, as this package reduces battery drain when idle.",
     "dependencies": [],
     "neededBy": [],
@@ -21565,7 +21565,7 @@
   },
   {
     "id": "com.google.android.apps.wearable.settings",
-    "list": "WearOS",
+    "list": "Oem",
     "description": "WearOS settings",
     "dependencies": [],
     "neededBy": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20941,5 +20941,464 @@
     "neededBy": [],
     "labels": [],
     "removal": "Expert"
-  }
+  },
+  {
+    "id": "com.google.android.wearable.assistant",
+    "list": "WearOS",
+    "description": "Google Assistant for Android wearables.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.google.android.wearable.batteryservices",
+    "list": "WearOS",
+    "description": "It's used to manage battery-related things on Android smartwatches, like monitoring the battery level, managing power consumption (auto battery saving I think), and handling battery-related events (pop-up when battery at 15%, etc.). It is typically used by developers to create battery-aware applications for wearable devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.advancedcallservice",
+    "list": "Oem",
+    "description": "Advanced Calling feature on an Android is a feature that allows you to make calls while using other applications with the use of CELLULAR DATA. In order for this feature to work, HD Voice must be enabled in settings.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.google.android.clockwork.oemsetup",
+    "list": "WearOS",
+    "description": "Installs carrier apps after the first time setup. Haven't noticed any concequences after uninstalling. I also saw some similar bloatware packages on the net, ending with clockwork.gestures.tutorial - first time use tutorial or clockwork.flashlight, clockwork.nfc, clockwork.brightness",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.google.android.apps.wearable.retailattractloop",
+    "list": "WearOS",
+    "description": "Demo mode - you see it in the stores (the video playing while idle).",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.mediacontroller",
+    "list": "WearOS",
+    "description": "Ability to controls phone's audio from your watch.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.shealthmonitor",
+    "list": "Oem",
+    "description": "Samsung Health Monitor\n\nEnables you to record ECG and blood pressure.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.watch.cameracontroller",
+    "list": "WearOS",
+    "description": "Mirrors phone's camera to your watch. I can't find a use case for my usage. Safe to remove.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.watch.findmywatch",
+    "list": "WearOS",
+    "description": "The watch will start ringing, if connected to phone via BT or WiFi, when pressing 'start ringing' on the phone. Also fetches location and is able to lock or factory reset.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.findmyphone",
+    "list": "WearOS",
+    "description": "The phone will start ringing, if connected to watch via BT or WiFi, when pressing 'start ringing' on the watch.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.runestone.app",
+    "list": "WearOS",
+    "description": "Customization Service from Samsung. IMHO doesn't do anything useful.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.analoguefont",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.animal",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.aremoji",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.basicclock",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.basicdashboard",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.bespoke",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.bitmoji",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.boldindex",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.digitalfont",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.digitalmodular",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.dualwatch",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.dynamicfont",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.gradientfont",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.healthmodular",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.infomodular",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.large",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.livewallpaper",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.mypebble",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.myphoto",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.mystyle",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.premiumanalog",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.simpleanalogue",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.simplecomplication",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.superfiction",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.together",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.typography",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.weather",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.weather",
+    "list": "WearOS",
+    "description": "Weather application from Samsung.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.watch.worldclock",
+    "list": "WearOS",
+    "description": "Worldclock app. This also includes a widget, displaying time in different time zones.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.wear.blockednumber",
+    "list": "WearOS",
+    "description": "Blocked number storage. Doesn't affect the dialer or contacts.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.wear.musictransfer",
+    "list": "WearOS",
+    "description": "Used to sync music with watch.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.wearable.setupwizard",
+    "list": "WearOS",
+    "description": "Safe to remove after first time setup.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  {
+    "id": "com.samsung.android.wear.contacts.sync",
+    "list": "WearOS",
+    "description": "Syncs contacts from phone to watch. I uninstalled it since i don't use my watch to call anyone.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.android.cts.ctsshim",
+    "list": "WearOS",
+    "description": "Basically an app for devs to compatibility test their app.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.cidmanager",
+    "list": "Oem",
+    "description": "In order to ensure that a user’s phone receives the appropriate firmware updates, this app is used to identify the carrier network. In other words - it helps to ensure that the correct country-specific firmware is delivered OTA.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.cidmanager",
+    "list": "Oem",
+    "description": "In order to ensure that a user’s phone receives the appropriate firmware updates, this app is used to identify the carrier network. In other words - it helps to ensure that the correct country-specific firmware is delivered OTA.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.wcs.exstention",
+    "list": "Oem",
+    "description": "Samsung Internet Extensions\nSamsung Internet for Android allows users to customize their browsing experience by installing extensions, which are additional software packages that add new features and functionality to the browser and help developers offer tailored services to users on mobile devices.\n\nNOTE: Disabling this broke the UI on my Watch5 for some reason so PROCEED WITH CAUTION.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.stextclassifier",
+    "list": "Oem",
+    "description": "From https://developer.android.com/reference/android/view/textclassifier/TextClassifier:\nInterface for providing text classification related features.\n\nThe TextClassifier may be used to understand the meaning of text, as well as generating predicted next actions based on the text.\n\nSo it got something to do with text/spelling correction? But a samsung implementation of it. It needs some further testing, so far it doesn't affect even the autocorrect.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.google.android.wearable.healthservices",
+    "list": "Oem",
+    "description": "Health Services by Google\nPlay Store link: https://play.google.com/store/apps/details?id=com.google.android.wearable.healthservices&hl=en_US&gl=US\n\nDisabling this on my Watch5 broke heart rate measuring and some workouts.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.service.health",
+    "list": "Oem",
+    "description": "Health Platform\n\nIt is a data aggregator. You can use it to link multiple health apps (like Strava, google fit etc) together. This app will unify their collected data and store them all together.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
 ]

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -21402,9 +21402,9 @@
     "removal": "Expert"
   },
   {
-    "id": "com.samsung.android.cidmanager",
+    "id": "com.samsung.packageinstalleroverlay",
     "list": "Oem",
-    "description": "In order to ensure that a user’s phone receives the appropriate firmware updates, this app is used to identify the carrier network. In other words - it helps to ensure that the correct country-specific firmware is delivered OTA.",
+    "description": "It's used to display an overlay window when installing or updating apps. Shows information about the app and provides the user with the option to cancel the process. Probably breaks manual installation of apps (needs more testing).",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -21400,5 +21400,5 @@
     "neededBy": [],
     "labels": [],
     "removal": "Expert"
-  },
+  }
 ]

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -21285,6 +21285,51 @@
     "removal": "Advanced"
   },
   {
+    "id": "com.samsung.android.watch.watchface.analogmodular",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.simpleclassic",
+    "list": "WearOS",
+    "description": "Preinstalled watchface.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.emergency",
+    "list": "WearOS",
+    "description": "Watchface in the emergency launcher.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.companionhelper",
+    "list": "WearOS",
+    "description": "Watchfaces fail to load without this. Removing it also breaks editing and changing watchfaces.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
+    "id": "com.samsung.android.watch.watchface.tickingsound",
+    "list": "WearOS",
+    "description": "Ticking sound on watchfaces that support it.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
     "id": "com.samsung.android.watch.weather",
     "list": "WearOS",
     "description": "Weather application from Samsung.",
@@ -21367,7 +21412,7 @@
   },
   {
     "id": "com.samsung.android.wcs.exstention",
-    "list": "Oem",
+    "list": "WearOS",
     "description": "Samsung Internet Extensions\nSamsung Internet for Android allows users to customize their browsing experience by installing extensions, which are additional software packages that add new features and functionality to the browser and help developers offer tailored services to users on mobile devices.\n\nNOTE: Disabling this broke the UI on my Watch5 for some reason so PROCEED WITH CAUTION.",
     "dependencies": [],
     "neededBy": [],
@@ -21382,6 +21427,24 @@
     "neededBy": [],
     "labels": [],
     "removal": "Advanced"
+  },
+  {
+    "id": "com.sec.android.soagent",
+    "list": "Oem",
+    "description": "System application that is responsible for checking and installing software updates.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Advanced"
+  },
+  {
+    "id": "com.samsung.packageinstalleroverlay",
+    "list": "Oem",
+    "description": "",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
   },
   {
     "id": "com.google.android.wearable.healthservices",


### PR DESCRIPTION
I was debloating my Watch5 and I found out that it would be much faster if there were descriptions of watch-specific aps on UAD as well. It took me around two days of research and testing that would took me about half an hour if the descriptions I provided were there. Most of the packages I described are from my watch.

I hope they help someone if you decide to add WearOS as another category. 

There are some more undocumented app that I'm willing to provide description for, I just need a little bit of motivation.