### PR TITLE
Dries up code repetition with idiomatic rust.

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -75,23 +75,15 @@ impl Config {
     }
 
     pub fn load_configuration_file() -> Self {
-        match fs::read_to_string(&*CONFIG_FILE) {
-            Ok(s) => match toml::from_str(&s) {
-                Ok(config) => config,
-                Err(e) => {
-                    error!("Invalid config file: `{}`", e);
-                    error!("Restoring default config file");
-                    let toml = toml::to_string(&Config::default()).unwrap();
-                    fs::write(&*CONFIG_FILE, toml).expect("Could not write config file to disk!");
-                    Config::default()
-                }
-            },
-            Err(_) => {
-                let default_conf = toml::to_string(&Config::default()).unwrap();
-                fs::write(&*CONFIG_FILE, default_conf)
-                    .expect("Could not write config file to disk!");
-                Config::default()
+        if let Ok(s) = fs::read_to_string(&*CONFIG_FILE) {
+            if let Ok(config) = toml::from_str(&s) {
+                return config;
             }
+            error!("Invalid config file: `{}`", e);
+            error!("Restoring default config file");
         }
+        let toml = toml::to_string(&Config::default()).unwrap();
+        fs::write(&*CONFIG_FILE, toml).expect("Could not write config file to disk!");
+        Config::default()
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -76,11 +76,13 @@ impl Config {
 
     pub fn load_configuration_file() -> Self {
         if let Ok(s) = fs::read_to_string(&*CONFIG_FILE) {
-            if let Ok(config) = toml::from_str(&s) {
-                return config;
+            match toml::from_str(&s) {
+                Ok(config) => return config,
+                Err(e) => {
+                    error!("Invalid config file: `{}`", e);
+                    error!("Restoring default config file");
+                }
             }
-            error!("Invalid config file: `{}`", e);
-            error!("Restoring default config file");
         }
         let toml = toml::to_string(&Config::default()).unwrap();
         fs::write(&*CONFIG_FILE, toml).expect("Could not write config file to disk!");

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -157,7 +157,7 @@ pub fn hashset_system_packages(state: PackageState, user_id: Option<&User>) -> H
         .unwrap_or_default()
         .replace("package:", "")
         .lines()
-        .map(|s| String::from(s))
+        .map(String::from)
         .collect()
 }
 

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -59,7 +59,8 @@ pub fn adb_shell_command(shell: bool, args: &str) -> Result<String, String> {
         false => vec![args],
     };
 
-    let command = Command::new("adb").args(adb_command);
+    let mut command = Command::new("adb");
+    command.args(adb_command);
 
     #[cfg(target_os = "windows")]
     let command = command.creation_flags(0x08000000); // do not open a cmd window
@@ -156,6 +157,7 @@ pub fn hashset_system_packages(state: PackageState, user_id: Option<&User>) -> H
         .unwrap_or_default()
         .replace("package:", "")
         .lines()
+        .map(|s| String::from(s))
         .collect()
 }
 
@@ -272,8 +274,8 @@ pub fn get_phone_brand() -> String {
     format!(
         "{} {}",
         adb_shell_command(true, "getprop ro.product.brand")
-            .map(|s| s.trim())
-            .unwrap_or(""),
+            .map(|s| s.trim().to_string())
+            .unwrap_or("".to_string()),
         get_phone_model()
     )
 }


### PR DESCRIPTION
### Changes:
- Uses short circuit logic for loading configuration file
- Only checks for windows as the target OS when running ADB shell commands since it needs the special 0x08000000 creation flag
- Parses shell output into string before checking success status since the output is used unconditionally
- Creates helper function `user_flag` when an additional `--user ` argument has to be supplied to `pm`
- Uses `unwrap_or_else` when we are only concerned with applying a function to an error 