### PR TITLE
pkg: add `com.huawei.android.hwouc`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -1782,6 +1782,14 @@
     "removal": "Recommended"
   },
   {
+    "id": "com.huawei.android.hwouc",
+    "list": "Oem",
+    "description": "Huawei EMUI System Update Service. Removing this will disable System updates and remove 'System & Updates -> Software update' from settings.(Highly recommended if you hate EMUI 12 and don't accidentally want to update to it)",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },  {
     "id": "com.huawei.android.instantonline",
     "list": "Oem",
     "description": "no noticable consequences\n",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -1784,7 +1784,7 @@
   {
     "id": "com.huawei.android.hwouc",
     "list": "Oem",
-    "description": "Huawei EMUI System Update Service.\nRemoving this will disable System updates and remove 'System & Updates -> Software update' from settings. Highly recommended if you hate EMUI 12 and don't accidentally want to update to it.",
+    "description": "Huawei EMUI System Update Service.\nRemoving this will disable System updates and remove 'System & Updates -> Software update' from settings. Highly recommended if you don't like the new, pending EMUI update and don't want to update to it.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -1784,7 +1784,7 @@
   {
     "id": "com.huawei.android.hwouc",
     "list": "Oem",
-    "description": "Huawei EMUI System Update Service. Removing this will disable System updates and remove 'System & Updates -> Software update' from settings.(Highly recommended if you hate EMUI 12 and don't accidentally want to update to it)",
+    "description": "Huawei EMUI System Update Service.\nRemoving this will disable System updates and remove 'System & Updates -> Software update' from settings. Highly recommended if you hate EMUI 12 and don't accidentally want to update to it.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Added a new package com.huawei.android.hwouc to expert list. Earlier was unlisted.
Tested on Samsung Huawei P30 lite. Remove `Software updates` from settings. Safe to remove.