### PR TITLE
Refactor core/save.rs to be more concise

### DIFF
--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -118,10 +118,12 @@ pub fn restore_backup(
 
             let mut commands = vec![];
             for u in phone_backup.users {
-                let index = match selected_device.user_list.iter().find(|x| x.id == u.id) {
-                    Some(i) => i.index,
-                    None => return Err(format!("user {} doesn't exist", u.id)),
-                };
+                let index = selected_device
+                    .user_list
+                    .iter()
+                    .find(|x| x.id == u.id)
+                    .ok_or(format!("user {} doesn't exist", u.id))?
+                    .index;
 
                 for (i, backup_package) in u.packages.iter().enumerate() {
                     let package: CorePackage = packages[index]

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -35,17 +35,8 @@ pub async fn backup_phone(
     };
 
     for u in users {
-        let mut user_backup = UserBackup {
-            id: u.id,
-            ..UserBackup::default()
-        };
-
-        for p in phone_packages[u.index].clone() {
-            user_backup.packages.push(CorePackage {
-                name: p.name.clone(),
-                state: p.state,
-            });
-        }
+        let packages: Vec<CorePackage> = phone_packages[u.index].iter().map(|p| p.into()).collect();
+        let user_backup = UserBackup { id: u.id, packages };
         backup.users.push(user_backup);
     }
 

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -75,15 +75,15 @@ pub fn list_available_backup_user(backup: DisplayablePath) -> Vec<User> {
             let phone_backup: PhoneBackup =
                 serde_json::from_str(&data).expect("Unable to parse backup file");
 
-            let mut users = vec![];
-            for u in phone_backup.users {
-                users.push(User {
+            phone_backup
+                .users
+                .iter()
+                .map(|u| User {
                     id: u.id,
                     index: 0,
                     protected: false,
-                });
-            }
-            users
+                })
+                .collect()
         }
         Err(e) => {
             error!("[BACKUP]: Selected backup file not found: {}", e);

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -104,13 +104,12 @@ pub fn restore_backup(
     settings: &DeviceSettings,
 ) -> Result<Vec<BackupPackage>, String> {
     match fs::read_to_string(
-        settings
+        &settings
             .backup
             .selected
             .as_ref()
             .ok_or("field should be Some type")?
-            .path
-            .clone(),
+            .path,
     ) {
         Ok(data) => {
             let phone_backup: PhoneBackup =

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -124,19 +124,14 @@ pub fn restore_backup(
                 };
 
                 for (i, backup_package) in u.packages.iter().enumerate() {
-                    let package: CorePackage;
-                    match packages[index]
+                    let package: CorePackage = packages[index]
                         .iter()
                         .find(|x| x.name == backup_package.name)
-                    {
-                        Some(p) => package = p.into(),
-                        None => {
-                            return Err(format!(
-                                "{} not found for user {}",
-                                backup_package.name, u.id
-                            ))
-                        }
-                    }
+                        .ok_or(format!(
+                            "{} not found for user {}",
+                            backup_package.name, u.id
+                        ))?
+                        .into();
                     let p_commands = apply_pkg_state_commands(
                         &package,
                         backup_package.state,

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -64,8 +64,8 @@ pub fn list_available_backups(dir: &Path) -> Vec<DisplayablePath> {
         Ok(files) => files
             .filter_map(|e| e.ok())
             .map(|e| DisplayablePath { path: e.path() })
-            .collect::<Vec<_>>(),
-        Err(_) => vec![],
+            .collect(),
+        _ => vec![],
     }
 }
 

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -52,10 +52,7 @@ pub async fn backup_phone(
             let backup_filename =
                 format!("{}.json", chrono::Local::now().format("%Y-%m-%d_%H-%M-%S"));
 
-            match fs::write(backup_path.join(backup_filename), json) {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err.to_string()),
-            }
+            fs::write(backup_path.join(backup_filename), json).map_err(|e| e.to_string())
         }
         Err(err) => Err(err.to_string()),
     }

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 pub static BACKUP_DIR: PathBuf = CACHE_DIR.join("backups");
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-struct PhoneBackup {
-    device_id: String,
+struct PhoneBackup<'a> {
+    device_id: &'a str,
     users: Vec<UserBackup>,
 }
 
@@ -38,7 +38,7 @@ pub async fn backup_phone(
         .collect();
 
     let backup = PhoneBackup {
-        device_id: device_id.clone(),
+        device_id: &device_id,
         users,
     };
 


### PR DESCRIPTION
### Changes:
- Removes unnecessary use of the `mut` keyword followed by struct modification. Instead, dependencies are initialized first.
- In cases where only the `None` variant of `Option` results in an error, uses `ok_or`.
- In cases where only the `Err` variant of a `Result` results in an custom error, uses `map_err`.
- Allows the compiler to infer types wherever it can instead of explicitly stating so.
- Removes unnecessary cloning of a `PathBuf` when reading file to string.