### PR TITLE
set windows_subsystem only in release mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
This helps in viewing log messages, etc in the console when running in debug mode locally, eg., `cargo run`

![image](https://github.com/0x192/universal-android-debloater/assets/715417/16a5c0b0-f381-44d9-b374-3c5298c133e5)
