### PR TITLE
pkg: `com.android.cellbroadcastreceiver.module`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -6930,6 +6930,15 @@
     "removal": "Expert"
   },
   {
+    "id": "com.android.cellbroadcastreceiver.module",
+    "list": "Aosp",
+    "description": "Same as com.android.cellbroadcastreceiver.\nCell broadcasting used to send emergency alerts.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast.",
+    "dependencies": ["com.android.cellbroadcastreceiver"],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
     "id": "com.android.contacts",
     "list": "Aosp",
     "description": "AOSP Contacts\nSome OEMs(for example Xiaomi) use the same package name for their app.",


### PR DESCRIPTION
Adds `com.android.cellbroadcastreceiver.module`. Removing the other packages relating to emergency alerts didn't fully get rid of the "feature", but this one does. Tested on my phone and it works, but keeping it at "Expert" in line with the other packages.



<details>
	<summary>Screenshot as proof of package</summary>

![Screenshot_20230910-051455_Settings](https://github.com/0x192/universal-android-debloater/assets/61523203/8f8c9a1d-d76d-4e72-a013-cba9bff62e10)
</details>


