### PR TITLE
Fix dependency proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2547,6 +2547,7 @@ dependencies = [
  "iced",
  "iced_native",
  "log",
+ "proc-macro2",
  "regex",
  "retry",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ toml = "^0"
 dirs = "^5.0.0"
 ureq = { version = "*", features = ["json"] }
 retry = { version = "^2.0.0" }
+proc-macro2 = "1.0.66" 
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 flate2 = { version = "^1", optional = true }
@@ -41,3 +42,4 @@ tar = { version = "^0.4", optional = true }
 opt-level = "s"
 lto = true
 strip = "symbols"
+


### PR DESCRIPTION
Currently the app does not compile with the error message: `unknown feature proc_macro_span_shrink`.

This PR sets the minimum version for the proc-macro2 crate to `1.0.66` so that the app compiles again.