### PR TITLE
Expand information for Xiaomi's videoplayer package

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -15806,7 +15806,7 @@
   {
     "id": "com.miui.videoplayer",
     "list": "Oem",
-    "description": "Mi Video (https://play.google.com/store/apps/details?id=com.miui.videoplayer)\n",
+    "description": "Mi Video (https://play.google.com/store/apps/details?id=com.miui.videoplayer)\n Seems to be a dependency for viewing/editing slow motion videos recorded with the stock camera on some Xiaomi devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
If you disable/uninstall the com.miui.videoplayer package in Poco F5 phones the stock camera is unable to record slow motion videos.