### PR TITLE
Extended description for com.google.android.googlequicksearchbox

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17363,7 +17363,7 @@
   {
     "id": "com.google.android.googlequicksearchbox",
     "list": "Google",
-    "description": "Google Search box (https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox)\nRuns in the background.\nPointless. If you need a shortcut to Google on your homescreen just use a web-browser shortcut. Does also remove the Google Sound Search widget, but you can get that functionality from an app like Shazam, that additionally doesn't run in the background constantly like this package does.",
+    "description": "Google Search box (https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox)\nRuns in the background.\nPointless. If you need a shortcut to Google on your homescreen just use a web-browser shortcut. Does also remove the Google Sound Search widget, but you can get that functionality from an app like Shazam, that additionally doesn't run in the background constantly like this package does. \nBut keep in mind this is needed by Google Lens to work.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Added that com.google.android.googlequicksearchbox is needed by Google Lens.